### PR TITLE
#109 and #110 about page updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,8 +75,8 @@
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <li><a href="https://secure.actblue.com/contribute/page/townhallproject" class="btn" id="donate-button" role="button" target="_blank">Donate</a></li>
-            <li><a class="social-icons" href="https://twitter.com/townhallproject" ><i class="fa fa-twitter-square fa-2x" aria-hidden="true"></i></a></li>
-            <li><a class="social-icons" href="https://www.facebook.com/TownHallProject/" ><i class="fa fa-facebook-square fa-2x" aria-hidden="true"></i></a></li>
+            <li><a class="social-icons" href="https://twitter.com/townhallproject" target="_blank"><i class="fa fa-twitter-square fa-2x" aria-hidden="true"></i></a></li>
+            <li><a class="social-icons" href="https://www.facebook.com/TownHallProject/" target="_blank"><i class="fa fa-facebook-square fa-2x" aria-hidden="true"></i></a></li>
             <li><a class="social-icons" href="mailto:info@townhallproject.com" class="text-white"><i class="fa fa-envelope-square fa-2x" aria-hidden="true"></i></a></li>
          </ul>
         </div>
@@ -297,7 +297,7 @@
               </div>
               <div class="col-sm-5 col-sm-offset-2">
                 <h3>What if my representatives have no public events scheduled?</h3>
-                <p>Call their <a href="https://www.govtrack.us/congress/members">district offices</a> and let them know you expect them to hold public events with their constituents. To have even more impact, join with other citizens in your district or state and organize group efforts. Visit the district office together, deliver petitions, inform your local press, or even hold an “Empty Chair” town hall and invite your member of Congress to fill that chair.</p>
+                <p>Call their <a href="https://www.govtrack.us/congress/members" target="_blank">district offices</a> and let them know you expect them to hold public events with their constituents. To have even more impact, join with other citizens in your district or state and organize group efforts. Visit the district office together, deliver petitions, inform your local press, or even hold an “Empty Chair” town hall and invite your member of Congress to fill that chair.</p>
               </div>
             </article>
             <article class="row text-center">
@@ -333,8 +333,8 @@
       <div class="container text-center">
         <ul class="list-unstyled">
           <li><a href="mailto:info@townhallproject.com" class="text-white"><i class="fa fa-envelope-square fa-3x" aria-hidden="true"></i></a>
-            <a href="https://twitter.com/townhallproject" class="text-white"><i class="fa fa-twitter-square fa-3x" aria-hidden="true"></i></a>
-            <a href="https://www.facebook.com/TownHallProject/" class="text-white"><i class="fa fa-facebook-square fa-3x" aria-hidden="true"></i></a>
+            <a href="https://twitter.com/townhallproject" class="text-white" target="_blank"><i class="fa fa-twitter-square fa-3x" aria-hidden="true"></i></a>
+            <a href="https://www.facebook.com/TownHallProject/" class="text-white" target="_blank"><i class="fa fa-facebook-square fa-3x" aria-hidden="true"></i></a>
           </li>
           <li><small>Compiled by Town Hall Project volunteers. All efforts are made to verify accuracy of events.</small></li>
           <li><small>Event details can change at short notice, please contact your representative to confirm.</small></li>

--- a/index.html
+++ b/index.html
@@ -276,11 +276,15 @@
               </div>
               <div class="col-sm-4">
                 <h3>What to expect</h3>
-                <p>The most powerful thing you can do, as a constituent, is <strong>ask an earnest, pressing question on an issue close to you.</strong> Your personal story is incredibly valuable. It’s precisely how sometimes dry policy is connected with the lives of real people. It’s not always easy to speak up, but these times call for courage in all of us. Take the mic and tell your representative why she or he needs to act in your best interest.
-                <p>The Town Hall Project strongly encourages you to only attend and ask questions of your own representatives. Remember that any town hall has limited time, and a question you take is one less question for a constituent.</p>
-                <p>For more, we recommend the valuable <a href="https://www.indivisibleguide.com/">Indivisible Guide</a>, which goes into detail on town hall best practices and other ways to hold your elected representatives accountable.</p>
-              </div>
+                <p>The most powerful thing you can do, as a constituent, is ask an earnest, pressing question on an issue close to you. <strong>Your personal story is incredibly valuable.</strong> It’s precisely how sometimes dry policy is connected with the lives of real people. It’s not always easy to speak up, but these times call for courage in all of us. Take the mic and tell your representative why she or he needs to act in your best interest.</p>
 
+                <p>The Town Hall Project strongly encourages you to only attend and ask questions of your own representatives. Remember that any town hall has limited time, and a question you take is one less question for a constituent.</p>
+
+                <ul>For more, we recommend:
+                  <li>Indivisible's <a href="//www.indivisibleguide.com/resource/town-halls/" target="_blank">Town Hall strategy resources</a></li>
+                  <li>CAP Action's <a href="//www.resistanceinyourpocket.com/" target="_blank">Recess Toolkit</a></li>
+                  <li>MoveOn.org's <a href="//www.resistancerecess.com/survey/resistance-aprilrecess-materials/" target="_blank">Resistance Recess</a></li>
+                </ul>
             </article>
           </section>
           <div class="banner" id="hand-raised">

--- a/index.html
+++ b/index.html
@@ -248,43 +248,51 @@
               <p class="text-primary"><strong>Show Up. Speak Out.</strong></p>
             </article>
             <article class="row">
-              <div class="col-sm-4">
-                <h3>Why Town Halls</h3>
-                <p>There is no better way to influence your representatives than in-person conversations. Town halls are a longstanding American tradition--where our elected representatives must listen and respond to the concerns of their constituents. Remember: you are their boss.
-                </p>
-                <p>We believe every citizen, no matter the party of their members of Congress, should have the opportunity to speak with his or her representatives.</p>
-
-                <p>
-                  You have more power than you think. Town halls are one of the most effective ways to use it.
-                </p>
-              </div>
-              <div class="col-sm-4">
+              <div class="col-sm-6">
                 <h3>About the Events</h3>
-                <p>Our project is currently focused on federal elected officials. We strongly believe that state legislatures deserve attention and citizen engagement, but at the moment these events are outside our current mission.
-                <ul>Our event listing includes:
+                <p>Our project is currently focused on federal elected officials. We strongly believe that state legislatures deserve attention and citizen engagement, but at the moment these events are outside our current mission.</p>
+
+                <p>Our event listing includes:</p>
+                <ul>
                   <li>Town halls</li>
                   <li>Other public events with members of Congress in their district/state</li>
                   <li>Ticketed events in the district/state</li>
                   <li>Staff office hours</li>
                   <li>Opportunities in Washington, D.C. to speak with your representative</li>
                 </ul>
-                <ul>We do not currently include:
+
+                <p>We do not currently include:</p>
+                <ul>
                   <li>Fundraisers outside the district/state</li>
-                  <li>Events where it would be inappropriate to ask policy questions of your representative (i.e. a funeral)</li>
+                  <li>Inappropriate events to ask policy questions at (e.g. funerals)</li>
                   <li>Campaign events where the member will not take questions</li>
                 </ul>
               </div>
-              <div class="col-sm-4">
+              <div class="col-sm-6">
                 <h3>What to expect</h3>
                 <p>The most powerful thing you can do, as a constituent, is ask an earnest, pressing question on an issue close to you. <strong>Your personal story is incredibly valuable.</strong> It’s precisely how sometimes dry policy is connected with the lives of real people. It’s not always easy to speak up, but these times call for courage in all of us. Take the mic and tell your representative why she or he needs to act in your best interest.</p>
-
                 <p>The Town Hall Project strongly encourages you to only attend and ask questions of your own representatives. Remember that any town hall has limited time, and a question you take is one less question for a constituent.</p>
 
-                <ul>For more, we recommend:
+                <p>For more, we recommend:</p>
+                <ul>
                   <li>Indivisible's <a href="//www.indivisibleguide.com/resource/town-halls/" target="_blank">Town Hall strategy resources</a></li>
                   <li>CAP Action's <a href="//www.resistanceinyourpocket.com/" target="_blank">Recess Toolkit</a></li>
                   <li>MoveOn.org's <a href="//www.resistancerecess.com/survey/resistance-aprilrecess-materials/" target="_blank">Resistance Recess</a></li>
                 </ul>
+              </div>
+            </article>
+            <article class="row">
+              <div class="col-sm-6">
+                <h3>Why Town Halls</h3>
+                <p>There is no better way to influence your representatives than in-person conversations. Town halls are a longstanding American tradition--where our elected representatives must listen and respond to the concerns of their constituents. Remember: you are their boss.</p>
+                <p>We believe every citizen, no matter the party of their members of Congress, should have the opportunity to speak with his or her representatives.</p>
+                <p>You have more power than you think. Town halls are one of the most effective ways to use it.</p>
+              </div>
+              <div class="col-sm-6">
+                <h3>Our Supporters</h3>
+                <p>Town Hall Project is possible because of the hard work of researchers, organizers, and developers across country, and the generous support of hundreds of grassroots donors.</p>
+                <p>We are also proud to partner with <a href="//www.americanprogressaction.org/resistance-near-me/" target="_blank">CAP Action</a>, <a href="//www.resistancerecess.com/event/resistance-aprilrecess/search/" target="_blank">MoveOn.org</a>, <a href="//nextgenclimate.org/" target="_blank">NextGen Climate</a>, and other progressive allies in supporting grassroots action to hold our elected officials accountable.</p>
+              </div>
             </article>
           </section>
           <div class="banner" id="hand-raised">

--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                 <p>We do not currently include:</p>
                 <ul>
                   <li>Fundraisers outside the district/state</li>
-                  <li>Inappropriate events to ask policy questions at (e.g. funerals)</li>
+                  <li>Inappropriate events to ask policy questions (e.g. funerals)</li>
                   <li>Campaign events where the member will not take questions</li>
                 </ul>
               </div>


### PR DESCRIPTION
This closes #109 and closes #110.  

I also added target="_blank" to all of the external links in index.html

@nathanmwilliams I slightly changed the language on the "We do not currently include" section from                   "Events where it would be inappropriate to ask policy questions of your representative (i.e. a funeral)" to "Inappropriate events to ask policy questions at (e.g. funerals)".  Lemme know if that's a problem copy wise, but I wanted to try and fit it on a single line as that section is already larger than everything else.

@meganrm I switched the 3col layout to a 2col.  Could keep 4 at lg/xl but it still looked kinda smushed.  And this way it matches the row under the banner.  We could also put the Our Supporters down under the banner (and make both 3col) but it doesn't really seem to match the content.