### PR TITLE
Feature/mb map markers and reps

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
                     <li class="dropdown">
                       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Party <span class="caret"></span></a>
                       <ul class="dropdown-menu filter">
-                        <li class="downdown-title">Filtery by party</li>
+                        <li class="downdown-title">Filter by party</li>
                         <li role="separator" class="divider"></li>
                         <li><a data-filter="Party" id="Democratic" class="dropdown-item" href="#">Democratic</a></li>
                         <li><a data-filter="Party" id="Republican" class="dropdown-item" href="#">Republican</a></li>

--- a/scripts/models/TownHall.js
+++ b/scripts/models/TownHall.js
@@ -114,11 +114,23 @@
     });
   };
 
-  TownHall.lookupReps = function (key, zip) {
-    var representativePromise = $.ajax({
-      url: 'https://congress.api.sunlightfoundation.com/legislators/locate?' + key + '=' + zip,
-      dataType: 'jsonp'
-    });
+  TownHall.lookupReps = function (key, value) {
+    if (key === 'zip') {
+      var representativePromise = $.ajax({
+        url: 'https://congress.api.sunlightfoundation.com/legislators/locate?' + key + '=' + value,
+        dataType: 'jsonp'
+      });
+    } else if (key === 'state') {
+      var representativePromise = $.ajax({
+        url: 'https://congress.api.sunlightfoundation.com/legislators?state=' + value + '&chamber=senate',
+        dataType: 'jsonp'
+      });
+    } else {
+      var representativePromise = $.ajax({
+        url: 'https://congress.api.sunlightfoundation.com/legislators?state=' + key + '&district=' + value,
+        dataType: 'jsonp'
+      });
+    }
     return representativePromise;
   };
 

--- a/scripts/views/eventView.js
+++ b/scripts/views/eventView.js
@@ -23,7 +23,11 @@
     //render table
     var districtText = ' ';
     validDistricts.forEach(function(district){
-      districtText = districtText + thisState + '-' + district + ' ';
+      if (district) {
+        districtText = districtText + thisState + '-' + district + ' ';
+      } else {
+        districtText = districtText + thisState;
+      }
     });
 
     var justSenate = true;
@@ -452,7 +456,8 @@
         history.replaceState({}, document.title, '.');
         setTimeout( function(){
           eventHandler.resetHome();
-        }, 0);
+          // mapView.resetView()
+        }, 1000);
       } else {
         location.hash = hashid;
       }

--- a/scripts/views/eventView.js
+++ b/scripts/views/eventView.js
@@ -31,10 +31,10 @@
     });
 
     var justSenate = true;
-    var numOfDistrictEvents = 0
+    var numOfDistrictEvents = 0;
     selectedData.forEach(function(ele){
       if(ele.District !== 'Senate') {
-        numOfDistrictEvents ++
+        numOfDistrictEvents ++;
         justSenate = false;
       }
     });
@@ -53,7 +53,7 @@
       eventHandler.renderTableWithArray(selectedData);
       mapView.makeSidebar(selectedData);
       var numOfSateEvents = selectedData.length - numOfDistrictEvents;
-      var message = '<p>Showing ' + numOfDistrictEvents + ' event(s) for ' + districtText + ' representatives</p>';
+      var message = '<p>Showing ' + numOfDistrictEvents + ' event(s) for the ' + districtText + ' representative</p>';
       var messageState = '<p>and ' + numOfSateEvents + ' event(s) for ' + thisState + ' senators</p>';
       $text.html(message + messageState);
 
@@ -145,29 +145,35 @@
     $panel.appendTo($parent);
   };
 
+  // renders the results of rep response
+  eventHandler.repCards = function(results, compiledTemplate, $parent) {
+    results.forEach(function(rep) {
+      switch(rep.party) {
+      case 'R':
+        rep.party = 'Republican';
+        break;
+      case 'D':
+        rep.party = 'Democrat';
+        break;
+      case 'I':
+        rep.party = 'Independent';
+        break;
+      }
+      var termEnd = new Date(rep.term_end);
+      // If term expires in janurary then assume the election is in the prior year
+      rep.electionYear = termEnd.getMonth() === 0 ? termEnd.getFullYear() - 1 : termEnd.getFullYear();
+      $parent.append(compiledTemplate(rep));
+    });
+  };
+
   // Display a list of reps with contact info
   eventHandler.renderRepresentativeCards = function(representativePromise, $parent, state) {
     $parent.empty(); // If they search for a new zipcode clear the old info
     representativePromise.success(function(representatives) {
       var compiledTemplate = Handlebars.getTemplate('representativeCard');
       $parent.append('<h2 class="text-primary text-center">Your Representatives</h2>');
-      representatives.results.forEach(function(rep) {
-        switch(rep.party) {
-        case 'R':
-          rep.party = 'Republican';
-          break;
-        case 'D':
-          rep.party = 'Democrat';
-          break;
-        case 'I':
-          rep.party = 'Independent';
-          break;
-        }
-        var termEnd = new Date(rep.term_end);
-        // If term expires in janurary then assume the election is in the prior year
-        rep.electionYear = termEnd.getMonth() === 0 ? termEnd.getFullYear() - 1 : termEnd.getFullYear();
-        $parent.append(compiledTemplate(rep));
-      });
+      eventHandler.repCards(representatives.results, compiledTemplate, $parent);
+
       if (representatives.results.length > 3) {
         $parent.append('<h4 class="col-md-12 text-center">Your zip code encompasses more than one district.<br><small><a href="http://www.house.gov/representatives/find/">Learn More</a></small></h4>');
       } else if (representatives.results.length === 1) {
@@ -176,30 +182,11 @@
     });
   };
 
-  // append additional reps
+  // append additional reps for lookup by district
   eventHandler.addRepresentativeCards = function(representativePromise, $parent) {
     representativePromise.success(function(representatives) {
       var compiledTemplate = Handlebars.getTemplate('representativeCard');
-      representatives.results.forEach(function(rep) {
-        switch(rep.party) {
-        case 'R':
-          rep.party = 'Republican';
-          break;
-        case 'D':
-          rep.party = 'Democrat';
-          break;
-        case 'I':
-          rep.party = 'Independent';
-          break;
-        }
-        var termEnd = new Date(rep.term_end);
-        // If term expires in janurary then assume the election is in the prior year
-        rep.electionYear = termEnd.getMonth() === 0 ? termEnd.getFullYear() - 1 : termEnd.getFullYear();
-        $parent.append(compiledTemplate(rep));
-      });
-      if (representatives.results.length > 3) {
-        $parent.append('<h4 class="col-md-12 text-center">Your zip code encompasses more than one district.<br><small><a href="http://www.house.gov/representatives/find/">Learn More</a></small></h4>');
-      }
+      eventHandler.repCards(representatives.results, compiledTemplate, $parent);
     });
   };
 

--- a/scripts/views/eventView.js
+++ b/scripts/views/eventView.js
@@ -31,8 +31,10 @@
     });
 
     var justSenate = true;
+    var numOfDistrictEvents = 0
     selectedData.forEach(function(ele){
       if(ele.District !== 'Senate') {
+        numOfDistrictEvents ++
         justSenate = false;
       }
     });
@@ -50,8 +52,10 @@
       TownHall.currentContext = selectedData;
       eventHandler.renderTableWithArray(selectedData);
       mapView.makeSidebar(selectedData);
-      var message = 'Showing ' + selectedData.length + ' event(s) for ' + districtText;
-      $text.html(message);
+      var numOfSateEvents = selectedData.length - numOfDistrictEvents;
+      var message = '<p>Showing ' + numOfDistrictEvents + ' event(s) for ' + districtText + ' representatives</p>';
+      var messageState = '<p>and ' + numOfSateEvents + ' event(s) for ' + thisState + ' senators</p>';
+      $text.html(message + messageState);
 
       selectedData.forEach(function(ele){
         eventHandler.renderPanels(ele, $parent);
@@ -142,11 +146,40 @@
   };
 
   // Display a list of reps with contact info
-  eventHandler.renderRepresentativeCards = function(representativePromise, $parent) {
+  eventHandler.renderRepresentativeCards = function(representativePromise, $parent, state) {
     $parent.empty(); // If they search for a new zipcode clear the old info
     representativePromise.success(function(representatives) {
       var compiledTemplate = Handlebars.getTemplate('representativeCard');
       $parent.append('<h2 class="text-primary text-center">Your Representatives</h2>');
+      representatives.results.forEach(function(rep) {
+        switch(rep.party) {
+        case 'R':
+          rep.party = 'Republican';
+          break;
+        case 'D':
+          rep.party = 'Democrat';
+          break;
+        case 'I':
+          rep.party = 'Independent';
+          break;
+        }
+        var termEnd = new Date(rep.term_end);
+        // If term expires in janurary then assume the election is in the prior year
+        rep.electionYear = termEnd.getMonth() === 0 ? termEnd.getFullYear() - 1 : termEnd.getFullYear();
+        $parent.append(compiledTemplate(rep));
+      });
+      if (representatives.results.length > 3) {
+        $parent.append('<h4 class="col-md-12 text-center">Your zip code encompasses more than one district.<br><small><a href="http://www.house.gov/representatives/find/">Learn More</a></small></h4>');
+      } else if (representatives.results.length === 1) {
+        eventHandler.addRepresentativeCards(TownHall.lookupReps('state', state), $('#representativeCards section'));
+      }
+    });
+  };
+
+  // append additional reps
+  eventHandler.addRepresentativeCards = function(representativePromise, $parent) {
+    representativePromise.success(function(representatives) {
+      var compiledTemplate = Handlebars.getTemplate('representativeCard');
       representatives.results.forEach(function(rep) {
         switch(rep.party) {
         case 'R':

--- a/scripts/views/mapView.js
+++ b/scripts/views/mapView.js
@@ -100,6 +100,15 @@
       var feature = {};
 
       if (1) {
+        var points = map.queryRenderedFeatures(e.point, { layers: ['townhall-points'] });
+        // selected a marker
+        if (points.length > 0) {
+          feature.state = points[0].properties.stateAbbr;
+          feature.district = points[0].properties.districtId;
+          feature.geoID = points[0].properties.stateCode + feature.district;
+          mapView.districtSelect(feature);
+          return;
+        }
         var features = map.queryRenderedFeatures(
           e.point,
           {
@@ -135,13 +144,16 @@
     var plusOrMinus1 = Math.random() < 0.5 ? -1 : 1;
     return [lng + jitter * plusOrMinus, lat + jitter * plusOrMinus1];
   }
+
+  function zeroPad(districtID) {
+    var padding = '00';
+    return padding.substring(0, padding.length - districtID.length) + districtID;
+  };
   // puts tele town halls by House members in the district.
   //TODO: geocode the data on the way in
   function teleTownHallDistrict(townhall){
     var districtId = townhall.District.split('-')[1];
-    if (districtId.length === 1){
-      districtId = '0' + districtId;
-    }
+    districtId = zeroPad(districtId);
 
     var bb = bboxes[townhall.District.split('-')[0] + districtId];
     townhall.lng = (bb[2] - bb[0])/2 + bb[0];
@@ -157,6 +169,7 @@
   // Creates the point layer.
   function makePoint (townhall) {
     var type = townhall.meetingType.toLowerCase();
+    var districtId = '';
     if (type === 'teletown hall' || type === 'tele-town hall'){
       var iconKey = 'phone-in';
       if (townhall.District && townhall.District !== 'Senate') {
@@ -165,6 +178,18 @@
     } else {
       var iconKey = 'in-person';
     }
+    if (townhall.District && townhall.District !== 'Senate') {
+      if (!townhall.District.split('-')[1]) {
+        return;
+      }
+      districtId = zeroPad(townhall.District.split('-')[1]);
+      stateAbbr = townhall.District.split('-')[0];
+    }
+    var state = stateData.filter(function(ele){
+      return ele.Name === townhall.State;
+    });
+    stateAbbr = state[0].USPS;
+    stateCode = state[0].FIPS;
     if (townhall.lat) {
       featuresHome.features.push({
         type: 'Feature',
@@ -174,6 +199,9 @@
         },
         properties: {
           district: townhall.District,
+          districtId: districtId,
+          stateCode: stateCode,
+          stateAbbr: stateAbbr,
           member: townhall.Member,
           meetingType: townhall.meetingType,
           icon: iconKey
@@ -208,6 +236,9 @@
       }
     }, 'district_interactive');
   }
+
+
+
   // Adds a Popup listener to the point layer. TODO: Determine content for the popup.
   function addPopups () {
     var popup = new mapboxgl.Popup({
@@ -306,7 +337,7 @@
       width = window.innerWidth,
       statekey = stateAbbr,
       bb = bboxes[stateAbbr];
-    if (districtCodes && districtCodes.length ===1) {
+    if (districtCodes && districtCodes.length === 1) {
       statekey = statekey + districtCodes[0];
       bb = bboxes[statekey];
     } else if (districtCodes && districtCodes.length > 1) {
@@ -356,6 +387,7 @@
     townHallsFB.once('value', function(snap) {
     // console.log("initial data loaded!", snap.numChildren() === TownHall.allTownHalls.length);
       map.getSource('townhall-points').setData(featuresHome);
+      // console.log(featuresHome);
       eventHandler.zipSearchByParam();
     });
   };

--- a/scripts/views/mapView.js
+++ b/scripts/views/mapView.js
@@ -62,7 +62,7 @@
 
     var text = $('h4');
     text.html(' ');
-
+    $('#representativeCards section').empty();
     eventHandler.setUrlParameter('zipcode', false);
     eventHandler.setUrlParameter('district', false);
   };
@@ -83,6 +83,8 @@
   mapView.districtSelect = function(feature) {
     if (feature.state) {
       eventHandler.renderResults(feature.state, [feature.district], feature.geoID);
+      eventHandler.renderRepresentativeCards(TownHall.lookupReps(feature.state, feature.district), $('#representativeCards section'), feature.state);
+
       eventHandler.setUrlParameter('zipcode', false);
       eventHandler.setUrlParameter('district', feature.state + '-' + feature.district + '-' + feature.geoID);
     } else {


### PR DESCRIPTION
I added a check in the map click listener. If the user clicks on a marker it returns results based on the marker instead of where they clicked (for cases where the marker overlaps into another district or state). If the event is a senate event it returns the state. 
I also added representative results for clicking on the map to be consistent with what returns when you search by zip. 