### PR TITLE
Style changes for the results panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,10 +155,11 @@
           </div>
         </div>
         <div class="header-with-results map-container-split hidden">
-          <div class="row">
+          <div class="row row-no-margin">
             <div class="col-md-6">
               <section class="results multipleResults">
-                <div id="nearest" class="flexcroll nearest-with-results"></div>
+                <div id="nearest" class="event-card__container nearest-with-results"></div>
+                <div class="nearest-cover"></div>
               </section>
             </div>
             <div class="col-md-6 map-small map-fixing">

--- a/scripts/views/eventView.js
+++ b/scripts/views/eventView.js
@@ -62,6 +62,23 @@
       selectedData.forEach(function(ele){
         eventHandler.renderPanels(ele, $parent);
       });
+
+      var leftColumnHeight = 0,
+        rightColumnHeight = 0,
+        articles = $('.event-card');
+
+      for (var i = 0; i < articles.length; i++) {
+        articles[i].setAttribute('height', 'height:' + articles[i].offsetHeight);
+
+        console.log(leftColumnHeight, rightColumnHeight)
+
+        if (leftColumnHeight > rightColumnHeight) {
+          rightColumnHeight += articles.eq(i).addClass('event-card-right').outerHeight(true);
+        } else {
+          leftColumnHeight += articles.eq(i).outerHeight(true);
+        }
+      }
+
       addtocalendar.load();
     } else {
       $text.html('There are no events for ' + districtText);

--- a/styles/customboot.less
+++ b/styles/customboot.less
@@ -349,7 +349,10 @@ a.social-icon {
  }
 }
 
-.list-group { margin-bottom: 0; }
+.list-group {
+  margin-bottom: 0;
+  overflow-wrap: break-word;
+}
 .event-card { margin-bottom: 1rem; }
 
 .panel-heading_in-person  { background-color: #439cbf; }
@@ -667,7 +670,7 @@ a.social-icon {
 }
 
 #nearest {
-  padding-top:10px;
+  padding: 20px 0 0.5rem 0;
   overflow-y: scroll;
   overflow-x: hidden;
   -ms-overflow-style: none;
@@ -1174,4 +1177,55 @@ img.grayscale {
   cursor: not-allowed;
   pointer-events: none;
   opacity: 0.5;
+}
+
+.event-card__container {
+  display: block;
+  width: 100%;
+  margin: 2% auto;
+}
+
+.event-card {
+  display: block;
+  width: 100%;
+  margin: 0 0 2%;
+  height: auto;
+  float: left;
+  clear: left;
+}
+
+.event-card-right {
+  float: right;
+  clear: right;
+}
+
+@media screen and (max-width: 959px){
+  .event-card {
+    width: 49%;
+  }
+
+  .panel {
+    min-height: auto
+  }
+}
+
+@media screen and (max-width: 650px){
+  .event-card {
+    width: 100%;
+  }
+}
+
+.row-no-margin {
+  margin: 0;
+}
+
+.nearest-cover {
+  position: absolute;
+  z-index: 99;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  box-shadow: inset 0px 30px 50px -20px #d4e0e5, inset 0px -35px 50px -20px #d4e0e5;
+  pointer-events: none;
 }


### PR DESCRIPTION
Went down a rabbit hole of fixing the results panel styling. Before all the cards were set to a minimum height, which led to a lot of empty long spaces, and large gaps between the cards.

This PR:
- Adds a masonry layout to the cards for the tablet view
- Makes each card's height = to the content it has
- Adds an inset gradient effect to the results so it's a bit more visually clear that section is a scroll to see.

before:
<img width="1277" alt="screenshot 2017-08-11 01 10 43" src="https://user-images.githubusercontent.com/9341928/29202025-0cd95e68-7e32-11e7-8ca9-2496f01c4274.png">

after:
<img width="1272" alt="screenshot 2017-08-11 01 12 38" src="https://user-images.githubusercontent.com/9341928/29202027-11a081a6-7e32-11e7-94ee-41f5632acf5c.png">

before:
<img width="883" alt="screenshot 2017-08-11 01 11 38" src="https://user-images.githubusercontent.com/9341928/29202033-1a74be5a-7e32-11e7-8bb2-0e533d60327d.png">

after:
<img width="884" alt="screenshot 2017-08-11 01 12 49" src="https://user-images.githubusercontent.com/9341928/29202036-200074d6-7e32-11e7-9c47-f1222484381a.png">

