### PR TITLE
#228 missing member errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -542,7 +542,7 @@
         <header>
           <section class="container container-fluid">
             <div class="col-md-6 col-md-offset-3">
-              <p class="lead"><span id="mm-total-copy">188</span> members of Congress have not held a single in-person town hall this year.<span class="text-success"> Is yours one of them?</span></p>
+              <p class="lead"><span id="mm-total-copy">Many</span> members of Congress have not held a single in-person town hall this year.<span class="text-success"> Is yours one of them?</span></p>
             </div>
           </section>
           <nav class="navbar navbar-default">

--- a/index.html
+++ b/index.html
@@ -551,7 +551,10 @@
                 <div class="col-sm-6">
                   <button class="btn btn-primary btn-block" type="button" name="button" id="view-missing-member-report">View Jan-Sept Infographic</button>
                 </div>
-                <span class="col-sm-6" id="mm-current-state" data-current=0 data-total=0></span></li>
+                <span class="col-sm-6 transparent" id="mm-current-state" data-current=0 data-total=0">
+                  Viewing ### of ### total missing members
+                </span>
+              </li>
               <li class="block filter-button-group mm-filter-info-holder">
                 <ul class="nav navbar-nav" id="mm-filter-info">
                 </ul>
@@ -787,6 +790,6 @@
     <script src="/scripts/controllers/state-routes.js"></script>
 
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyALLuOh_q8phgScmZiVEJwkaK8NkUPkkrM&callback=initMap&libraries=visualization,geometry"></script>
-    
+
   </body>
 </html>

--- a/scripts/views/missingMembersView.js
+++ b/scripts/views/missingMembersView.js
@@ -109,6 +109,7 @@
       $('#mm-current-state').attr('data-total', missingMembers.length);
       // inital report of data
       $currentState.text('Viewing ' + missingMembers.length + ' of ' + missingMembers.length + ' total missing members');
+      $currentState.removeClass('transparent');
       $copy.text($currentState.attr('data-total'));
       // make cards
       missingMemberView.renderAll('missingMemberCard', '.grid', missingMembers);

--- a/styles/customboot.less
+++ b/styles/customboot.less
@@ -225,6 +225,10 @@ h1, h2 {
   display: none!important;
 }
 
+.transparent {
+  opacity: 0;
+}
+
 .navbar{
   border-bottom: @brand-secondary 2px solid;
   margin-bottom: 0;


### PR DESCRIPTION
This closes #228.

I decided to use "Many" as our placeholder text for "_____ members of Congress have not held a single in-person town hall this year. Is yours one of them?"  Alternatively we could hide the entire lead until we have data, but then it pops in and is pretty distracting.

I also fixed the bug where the "View Jan-Sept Infographic" button isn't wide enough for the first few seconds after load.