### PR TITLE
140 Include constants so it doesn't blow up

### DIFF
--- a/index.html
+++ b/index.html
@@ -906,6 +906,7 @@
     <script src="/data/statePop.js"></script>
 
     <script src="/scripts/models/MemberOfCongress.js"></script>
+    <script src="/scripts/lib/constants.js"></script>
     <script src="/scripts/models/TownHall.js"></script>
     <script src="/scripts/models/UploadVideo.js"></script>
 
@@ -923,7 +924,7 @@
     <script src="/scripts/views/mapView.js"></script>
     <script src="/scripts/views/eventView.js"></script>
     <script src="/scripts/views/dataViz.js"></script>
-    
+
     <script src="/scripts/controllers/index-controller.js"></script>
     <script src="/scripts/controllers/map-controller.js"></script>
     <script src="/scripts/controllers/routes.js"></script>


### PR DESCRIPTION
Super tiny PR referencing https://github.com/meganrm/townHallProjectAdmin/issues/140

This plots the events on the map (it was blowing up cause constants were never imported) but does **NOT** yet display them during zip lookup.  We'll need to work on the backend before that's possible.