### PR TITLE
disable click over state mask

### DIFF
--- a/scripts/views/mapboxView.js
+++ b/scripts/views/mapboxView.js
@@ -248,6 +248,11 @@
   };
 
   function stateDistristListener(e) {
+    var checkIfValidState =  map.queryRenderedFeatures(e.point, { layers: ['state-mask'] });
+    if (checkIfValidState.length > 0 && checkIfValidState[0].layer.id === 'state-mask') {
+      return;
+    }
+    
     var feature = {};
 
     var features = map.queryRenderedFeatures(


### PR DESCRIPTION
adds a check to state map listener.

If click is over 'state-mask' layer, function returns without
querying for events/districts