### PR TITLE
edit Find an event button

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
                 <div class="form-group text-center">
                   <label for="zip"></label>
                   <input class="form-control input-lg " type="zip" name="" value="" placeholder="Zip Code">
-                  <button type="submit" name="button" class="btn btn-primary btn-lg fath-button">Find A Town Hall</button>
+                  <button type="submit" name="button" class="btn btn-primary btn-lg fath-button">Find An Event</button>
 
                   <div id="selection-results" class="text-center ">
                     <h4 class="selection-results_content"></h4>


### PR DESCRIPTION
This PR changes the text on primary search button from 'Find A Town Hall' to 'Find An Event' as issued in #413 