### PR TITLE
Remove 'DC Event' from glossary and filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,10 +547,6 @@
                 <span class="text-secondary">TeleTown Hall Meeting </span>
                 <span> - A town hall conducted by conference call or online.</span>
               </li>
-              <li>
-                <span class="text-secondary">DC Event</span>
-                <span> - Event held in Washington D.C. when Congress is in session.</span>
-              </li>
             </ul>
           </small>
         </div>
@@ -639,9 +635,6 @@
                       </li>
                       <li>
                         <a data-filter="meetingType" id="Campaign Town Hall" class="dropdown-item" href="#">Campaign Town Hall</a>
-                      </li>
-                      <li>
-                        <a data-filter="meetingType" id="DC Event" class="dropdown-item" href="#">DC Event</a>
                       </li>
                       <li>
                         <a data-filter="meetingType" id="All" class="dropdown-item" href="#">All</a>


### PR DESCRIPTION
Addressed Issue #465
- Delete 'DC Event' from 'Upcoming Events'
- Delete 'DC Event' from 'Event Type' dropdown