### PR TITLE
Remove opt in email checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,14 +14,16 @@
 
   <!-- Schema.org markup for Google+ -->
   <meta itemprop="name" content="Town Hall Project">
-  <meta itemprop="description" content="Town Hall Project is a progressive, a citizen-powered research and organizing project dedicated to holding lawmakers accountable via town hall meetings and other in-person engagement.">
+  <meta itemprop="description"
+    content="Town Hall Project is a progressive, a citizen-powered research and organizing project dedicated to holding lawmakers accountable via town hall meetings and other in-person engagement.">
   <meta itemprop="image" content="https://townhallproject.com/Images/THP_logo_horizontal_facebook.png">
 
   <!-- Twitter Card data -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@townhallproject">
   <meta name="twitter:title" content="Town Hall Project">
-  <meta name="twitter:description" content="Town Hall Project is a progressive, a citizen-powered research and organizing project dedicated to holding lawmakers accountable via town hall meetings and other in-person engagement.">
+  <meta name="twitter:description"
+    content="Town Hall Project is a progressive, a citizen-powered research and organizing project dedicated to holding lawmakers accountable via town hall meetings and other in-person engagement.">
   <meta name="twitter:creator" content="@townhallproject">
   <!-- Twitter summary card must be at least 120px x 120px -->
   <meta name="twitter:image" content="https://townhallproject.com/Images/THP_logo_vertical_twitter.png">
@@ -32,7 +34,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://townhallproject.com/" />
   <meta property="og:image" content="https://townhallproject.com/Images/THP_logo_horizontal_facebook.png">
-  <meta property="og:description" content="Town Hall Project is a progressive, a citizen-powered research and organizing project dedicated to holding lawmakers accountable via town hall meetings and other in-person engagement.">
+  <meta property="og:description"
+    content="Town Hall Project is a progressive, a citizen-powered research and organizing project dedicated to holding lawmakers accountable via town hall meetings and other in-person engagement.">
   <meta property="og:site_name" content="Town Hall Project" />
 
   <link href='https://actionnetwork.org/css/style-embed-whitelabel.css' rel='stylesheet' type='text/css' />
@@ -40,7 +43,7 @@
   <link href="https://addtocalendar.com/atc/1.5/atc-style-blue.css" rel="stylesheet" type="text/css">
   <link href="/vendor/styles/jquery-ui.min.css" rel="stylesheet" type="text/css">
   <link href="/vendor/styles/jquery-ui.structure.min.css" rel="stylesheet" type="text/css">
-  <link href="/vendor/styles/bootstrap-tagsinput.css" rel="stylesheet" type="text/css"  >
+  <link href="/vendor/styles/bootstrap-tagsinput.css" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Raleway:300,400,900" rel="stylesheet">
   <link href='https://api.mapbox.com/mapbox-gl-js/v0.32.1/mapbox-gl.css' rel='stylesheet' />
 
@@ -66,7 +69,8 @@
   <nav class="navbar navbar-default navbar-main">
     <div class="container-fluid">
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-nav" aria-expanded="false">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-nav"
+          aria-expanded="false">
           <span class="sr-only">Toggle navigation</span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -79,7 +83,8 @@
       <div class="collapse navbar-collapse" id="main-nav">
         <ul class="nav navbar-nav navbar-left" roll="tablists">
           <li class="dropdown dropdown--stateSelection">
-            <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true"
+              aria-expanded="true">
               <span class="button-text">State Legislatures</span>
               <span class="caret"></span>
             </button>
@@ -141,7 +146,8 @@
             <a class="hash-link" data-toggle="tab" href="#submit">Submit an event</a>
           </li>
           <li>
-            <a id="privacy-policy-link" class="hash-link hidden" data-toggle="tab" aria-hidden="true" href="#privacy-policy">Privacy Policy</a>
+            <a id="privacy-policy-link" class="hash-link hidden" data-toggle="tab" aria-hidden="true"
+              href="#privacy-policy">Privacy Policy</a>
           </li>
           <li>
             <a class="hash-link hidden" data-toggle="tab" aria-hidden="true" href="#thfol-guide">THFOL guide</a>
@@ -150,7 +156,7 @@
             <a class="hash-link hidden" data-toggle="tab" aria-hidden="true" href="#year-one">Look back at 2017</a>
           </li>
           <li>
-            <a class="hash-link hidden" data-toggle="tab"  aria-hidden="true" href="#year-two">Look back at 2018</a>
+            <a class="hash-link hidden" data-toggle="tab" aria-hidden="true" href="#year-two">Look back at 2018</a>
           </li>
           <li>
             <a class="hash-link hidden" data-toggle="tab" aria-hidden="true" href="#town-hall-pledge"></a>
@@ -181,7 +187,7 @@
     </div>
 
   </nav>
-  
+
   <div class="time-sensitive background-gray">
     <div class=" display-flex">
       <div class="happening-now-title">
@@ -189,18 +195,19 @@
         <h1><i class="fas fa-chevron-right"></i></h1>
       </div>
       <div class="happening-now-content">
-          <div class="text-center">
-            <h2 class="text-primary">
-              <a class="text-primary"
-              target="_blank"
-              href="https://docs.google.com/document/u/1/d/e/2PACX-1vS6KSUlV0xnNustop7KDBl__ht-R8XMqO7mWTB2Kb_XiEam9TE_mVaqbvI9lBkdJr6xNxT8T74r4jui/pub">Read our Jan-April 2019 Congressional Accessibility Report and see how this Congress stacks up <i class="fas fa-external-link-alt"></i></a>
-              </h2>
-            <button class="btn btn-primary " type="button" name="button" id="view-accessibility-report">Infographic
-            </button>
+        <div class="text-center">
+          <h2 class="text-primary">
+            <a class="text-primary" target="_blank"
+              href="https://docs.google.com/document/u/1/d/e/2PACX-1vS6KSUlV0xnNustop7KDBl__ht-R8XMqO7mWTB2Kb_XiEam9TE_mVaqbvI9lBkdJr6xNxT8T74r4jui/pub">Read
+              our Jan-April 2019 Congressional Accessibility Report and see how this Congress stacks up <i
+                class="fas fa-external-link-alt"></i></a>
+          </h2>
+          <button class="btn btn-primary " type="button" name="button" id="view-accessibility-report">Infographic
+          </button>
         </div>
       </div>
     </div>
-  </div> 
+  </div>
   <div class="tab-content">
     <div role="tabpanel" class="tab-pane page active" id="home">
       <header class="site-header clearfix">
@@ -225,7 +232,8 @@
                 <div class="form-group text-center">
                   <label for="zip"></label>
                   <input class="form-control input-lg " type="zip" name="" value="" placeholder="Zip Code">
-                  <button type="submit" name="button" class="btn btn-primary btn-lg fath-button">Find A Town Hall</button>
+                  <button type="submit" name="button" class="btn btn-primary btn-lg fath-button">Find A Town
+                    Hall</button>
 
                   <div id="selection-results" class="text-center ">
                     <h4 class="selection-results_content"></h4>
@@ -242,14 +250,17 @@
       <section class="background-light-blue" id="no-events">
         <div class="container container-fluid">
           <div class="col-md-12">
-            <h2 class="weight-heavy">There are no events with your representatives right now &mdash; but you can still make your voice heard!</h2>
+            <h2 class="weight-heavy">There are no events with your representatives right now &mdash; but you can still
+              make your voice heard!</h2>
             <h3>
               <a href=" https://5calls.org" target="_blank">Call</a>, write, or email your Senators or Representative.
               Write a letter to the editor in your local newspaper.
               Join an
-              <a href="https://indivisible.org/groups" target="_blank">Indivisible group</a> or other local activist organization to create change in your community.</h3>
+              <a href="https://indivisible.org/groups" target="_blank">Indivisible group</a> or other local activist
+              organization to create change in your community.</h3>
             <h3>If you hear of town halls or other events with your member of Congress, don’t hesitate to
-              <a class="hash-link" data-toggle="tab" href="#submit">submit them</a> to us so we can spread the word.</h3>
+              <a class="hash-link" data-toggle="tab" href="#submit">submit them</a> to us so we can spread the word.
+            </h3>
             <h3 class="weight-heavy">Show Up. Speak Out.</h3>
           </div>
         </div>
@@ -258,7 +269,8 @@
         <div class="hidden show-if-no-webgl webgl-banner">
           <div class="webGl-warning" target="_blank">
             <img class="webGl-compimg" src="../Images/map/ohno-computer.png"></img>
-            <p>Our interactive map feature uses WebGL, a plugin common in most modern browsers. Your browser does not have WebGL
+            <p>Our interactive map feature uses WebGL, a plugin common in most modern browsers. Your browser does not
+              have WebGL
               working currently.</p>
             <p>You can learn how to enable WebGL on
               <a href="https://get.webgl.org/" target="_blank">this website.</a>
@@ -313,14 +325,16 @@
             </ul>
             <ul class="state-lines list-inline hide-if-no-webgl hidden">
               <li class="map-legend-li">Showing: </li>
-              <button type="button" name="button" id="show-federal-borders" class="btn btn-xs btn-transparent border-toggle inactive">
+              <button type="button" name="button" id="show-federal-borders"
+                class="btn btn-xs btn-transparent border-toggle inactive">
                 <li class="map-legend-li interactive federal">
                   <dt class="map-legend-line map-legend__federal"></dt>
                   <dd>Congressional districts</dd>
                 </li>
                 </li>
               </button>
-              <button type="button" name="button" id="show-state-borders" class="btn btn-xs btn-transparent border-toggle active">
+              <button type="button" name="button" id="show-state-borders"
+                class="btn btn-xs btn-transparent border-toggle active">
                 <ul class="list-inline">
                   <li class="map-legend-li state">
                     <dt class="map-legend-line map-legend__state_lower"></dt>
@@ -414,12 +428,14 @@
                 <dt>Senate</dt>
                 <dd>
                   <div class="progress bar-graph">
-                    <div class="progress-bar progress-bar-dem-has-events dem-aug-total-senate" data-count=0 data-max=100>
+                    <div class="progress-bar progress-bar-dem-has-events dem-aug-total-senate" data-count=0
+                      data-max=100>
                       <span class="sr-only">Democratic progress</span>
                     </div>
                   </div>
                   <div class="progress bar-graph">
-                    <div class="progress-bar progress-bar-rep-has-events rep-aug-total-senate" data-count=0 data-max=100>
+                    <div class="progress-bar progress-bar-rep-has-events rep-aug-total-senate" data-count=0
+                      data-max=100>
                       <span class="sr-only">Democratic progress</span>
                     </div>
                   </div>
@@ -471,11 +487,13 @@
               </div>
               <div class="col-lg-4">
                 <div class="col-xs-12">
-                  <button type="submit" name="button" class="btn btn-primary btn-light-background btn-lg btn-block">Sign up</button>
+                  <button type="submit" name="button" class="btn btn-primary btn-light-background btn-lg btn-block">Sign
+                    up</button>
                 </div>
-                <div class="col-xs-12">
+                <div class="col-xs-12" style="display:none">
                   <label class="checkbox-inline">
-                    <input type="checkbox" value="" name="partner"> Opt in to receive updates from our progressive partners.
+                    <input type="checkbox" value="" name="partner"> Opt in to receive updates from our progressive
+                    partners.
                   </label>
                 </div>
               </div>
@@ -483,10 +501,10 @@
           </form>
         </div>
       </section>
-      
-    <div id="email-update" class="hidden background-light-blue container-fluid">
+
+      <div id="email-update" class="hidden background-light-blue container-fluid">
         <button id="open-email-form" class="btn btn-xs">Update your email subscription</button>
-    </div>
+      </div>
 
 
       <!-- Cards showing representatives and their contact info -->
@@ -518,7 +536,8 @@
             <ul class="list-unstyled container">
               <li>
                 <span class="text-secondary">Town Hall</span>
-                <span> - A forum where lawmakers give legislative updates and answer open questions from constituents.</span>
+                <span> - A forum where lawmakers give legislative updates and answer open questions from
+                  constituents.</span>
               </li>
               <li>
                 <span class="text-secondary">"Empty Chair" Town Hall</span>
@@ -530,17 +549,20 @@
               </li>
               <li>
                 <span class="text-secondary">Office Hours </span>
-                <span> - Opportunity to meet and question a lawmaker's staff. Usually held in district offices but sometimes are
+                <span> - Opportunity to meet and question a lawmaker's staff. Usually held in district offices but
+                  sometimes are
                   "mobile office hours."</span>
               </li>
               <li>
                 <span class="text-secondary">Campaign Town Hall </span>
-                <span> - A town hall organized by a candidate for office - whether an incumbent or challenger. (Town Hall Project
+                <span> - A town hall organized by a candidate for office - whether an incumbent or challenger. (Town
+                  Hall Project
                   includes these events as a public resource--not to endorse a particular candidate or campaign).</span>
               </li>
               <li>
                 <span class="text-secondary">Ticketed Event</span>
-                <span> - Paid events. Typically fundraisers. (Town Hall Project includes these events as a public resource--not
+                <span> - Paid events. Typically fundraisers. (Town Hall Project includes these events as a public
+                  resource--not
                   to endorse a particular candidate or campaign).</span>
               </li>
               <li>
@@ -561,20 +583,23 @@
                 </ul>
                 <ul id="all-events-table-dropdown-container" class="nav navbar-nav navbar-right">
                   <li class="dropdown hidden">
-                    <a href="#" class="dropdown-toggle hide-on-state-view" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Member
+                    <a href="#" class="dropdown-toggle hide-on-state-view" data-toggle="dropdown" role="button"
+                      aria-haspopup="true" aria-expanded="false">Member
                       <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                       <li class="downdown-title">Search by member of Congress</li>
                       <li role="separator" class="divider"></li>
                       <li>
-                        <input id="memberTypeahead" type="text" class="form-control dropdown-item filter" data-provide="typeahead"
-                          placeholder="Search by member" data-filter="displayName" autocomplete="off">
+                        <input id="memberTypeahead" type="text" class="form-control dropdown-item filter"
+                          data-provide="typeahead" placeholder="Search by member" data-filter="displayName"
+                          autocomplete="off">
                       </li>
                     </ul>
                   </li>
                   <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Party
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                      aria-expanded="false">Party
                       <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu filter">
@@ -596,20 +621,23 @@
                     </ul>
                   </li>
                   <li class="dropdown">
-                    <a href="#" class="dropdown-toggle hide-on-state-view" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">State
+                    <a href="#" class="dropdown-toggle hide-on-state-view" data-toggle="dropdown" role="button"
+                      aria-haspopup="true" aria-expanded="false">State
                       <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu">
                       <li class="downdown-title">Search by State</li>
                       <li role="separator" class="divider"></li>
                       <li>
-                        <input id="stateTypeahead" type="text" class="form-control dropdown-item filter" data-provide="typeahead"
-                          placeholder="Search by state" data-filter="stateName" autocomplete="off">
+                        <input id="stateTypeahead" type="text" class="form-control dropdown-item filter"
+                          data-provide="typeahead" placeholder="Search by state" data-filter="stateName"
+                          autocomplete="off">
                       </li>
                     </ul>
                   </li>
                   <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Event Type
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                      aria-expanded="false">Event Type
                       <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu filter">
@@ -619,7 +647,8 @@
                         <a data-filter="meetingType" id="Town Hall" class="dropdown-item" href="#">Town Hall</a>
                       </li>
                       <li>
-                        <a data-filter="meetingType" id="Empty Chair Town Hall" class="dropdown-item" href="#">Empty Chair Town Hall</a>
+                        <a data-filter="meetingType" id="Empty Chair Town Hall" class="dropdown-item" href="#">Empty
+                          Chair Town Hall</a>
                       </li>
                       <li>
                         <a data-filter="meetingType" id="Adopt-A-District/State" href="#">Adopt-A-District/State</a>
@@ -628,13 +657,16 @@
                         <a data-filter="meetingType" id="Office Hours" class="dropdown-item" href="#">Office Hours</a>
                       </li>
                       <li>
-                        <a data-filter="meetingType" id="Ticketed Event" class="dropdown-item" href="#">Ticketed Event</a>
+                        <a data-filter="meetingType" id="Ticketed Event" class="dropdown-item" href="#">Ticketed
+                          Event</a>
                       </li>
                       <li>
-                        <a data-filter="meetingType" id="Tele-Town Hall" class="dropdown-item" href="#">Tele-Town Hall</a>
+                        <a data-filter="meetingType" id="Tele-Town Hall" class="dropdown-item" href="#">Tele-Town
+                          Hall</a>
                       </li>
                       <li>
-                        <a data-filter="meetingType" id="Campaign Town Hall" class="dropdown-item" href="#">Campaign Town Hall</a>
+                        <a data-filter="meetingType" id="Campaign Town Hall" class="dropdown-item" href="#">Campaign
+                          Town Hall</a>
                       </li>
                       <li>
                         <a data-filter="meetingType" id="Youth Vote" class="dropdown-item" href="#">Youth Vote</a>
@@ -651,7 +683,8 @@
                     </ul>
                   </li>
                   <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Sort
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                      aria-expanded="false">Sort
                       <span class="caret"></span>
                     </a>
                     <ul class="dropdown-menu sort">
@@ -661,7 +694,8 @@
                         <a data-filter="dateObj" id="byDate" class="dropdown-item" href="#">By Date</a>
                       </li>
                       <li>
-                        <a data-filter="stateName" id="byState" class="dropdown-item hide-on-state-view" href="#">By State</a>
+                        <a data-filter="stateName" id="byState" class="dropdown-item hide-on-state-view" href="#">By
+                          State</a>
                       </li>
                       <li>
                         <a data-filter="displayName" id="byName" class="dropdown-item" href="#">By Name</a>
@@ -679,13 +713,15 @@
     </div>
     <div role="tabpanel" class="tab-pane" id="submit">
       <div class='embed-container submit-embed-container'>
-        <iframe src='https://docs.google.com/forms/d/e/1FAIpQLSfvIJikraQCZcqUpYfDZHC7KvxDUp4zcfzlLQ7RoaDQcBZUbQ/viewform?c=0&w=1'
+        <iframe
+          src='https://docs.google.com/forms/d/e/1FAIpQLSfvIJikraQCZcqUpYfDZHC7KvxDUp4zcfzlLQ7RoaDQcBZUbQ/viewform?c=0&w=1'
           style=" border-width:0 " width="800" height="600" frameborder="0"></iframe>
       </div>
     </div>
     <div role="tabpanel" class="tab-pane" id="contact">
       <div class='embed-container contact-embed-container'>
-        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSffVaop5xVSxXFrRtAZsxMDqkvucAplMdC9-CPHiTXxPKQV0g/viewform?embedded=true"
+        <iframe
+          src="https://docs.google.com/forms/d/e/1FAIpQLSffVaop5xVSxXFrRtAZsxMDqkvucAplMdC9-CPHiTXxPKQV0g/viewform?embedded=true"
           width="800" height="600" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
       </div>
     </div>
@@ -693,8 +729,10 @@
       <header>
         <section class="container container-fluid quote-header">
           <blockquote class="col-sm-6 col-sm-offset-3">
-            <p class="text-white">"It falls to each of us to be those anxious, jealous guardians of our democracy. Embrace the joyous task we have
-              been given to continually try to improve this great nation of ours because, for all our outward differences,
+            <p class="text-white">"It falls to each of us to be those anxious, jealous guardians of our democracy.
+              Embrace the joyous task we have
+              been given to continually try to improve this great nation of ours because, for all our outward
+              differences,
               we in fact all share the same proud type, the most important office in a democracy,
               <span class="text-secondary">citizen</span>."</p>
             <footer class="text-success">President Obama,
@@ -706,12 +744,16 @@
       <section class="container">
         <article class="center-block about">
           <h2 class="text-secondary-dark">About Town Hall Project</h2>
-          <p class="lead">Town Hall Project empowers constituents across the country to have face-to-face conversations with their elected
+          <p class="lead">Town Hall Project empowers constituents across the country to have face-to-face conversations
+            with their elected
             representatives. We are campaign veterans and first time volunteers. We come from a diversity of backgrounds
-            and live across the country. We share progressive values and believe strongly in civic engagement. We research
-            every district and state for public events with members of Congress. Then we share our findings to promote participation
+            and live across the country. We share progressive values and believe strongly in civic engagement. We
+            research
+            every district and state for public events with members of Congress. Then we share our findings to promote
+            participation
             in the democratic process.</p>
-          <p class="lead">This movement is diverse, open source, and powered by citizens. We are proud to be a part of it.</p>
+          <p class="lead">This movement is diverse, open source, and powered by citizens. We are proud to be a part of
+            it.</p>
           <p class="text-primary">
             <strong>Show Up. Speak Out.</strong>
           </p>
@@ -719,7 +761,8 @@
         <article class="row">
           <div class="col-sm-6">
             <h3>About the Events</h3>
-            <p>Our project is currently focused on federal elected officials. We strongly believe that state legislatures deserve
+            <p>Our project is currently focused on federal elected officials. We strongly believe that state
+              legislatures deserve
               attention and citizen engagement, but at the moment these events are outside our current mission.</p>
 
             <p>Our event listing includes:</p>
@@ -739,18 +782,22 @@
           </div>
           <div class="col-sm-6">
             <h3>What to expect</h3>
-            <p>The most powerful thing you can do, as a constituent, is ask an earnest, pressing question on an issue close
+            <p>The most powerful thing you can do, as a constituent, is ask an earnest, pressing question on an issue
+              close
               to you.
-              <strong>Your personal story is incredibly valuable.</strong> It’s precisely how sometimes dry policy is connected with
+              <strong>Your personal story is incredibly valuable.</strong> It’s precisely how sometimes dry policy is
+              connected with
               the lives of real people. It’s not always easy to speak up, but these times call for courage in all of us.
               Take the mic and tell your representative why she or he needs to act in your best interest.</p>
-            <p>The Town Hall Project strongly encourages you to only attend and ask questions of your own representatives. Remember
+            <p>The Town Hall Project strongly encourages you to only attend and ask questions of your own
+              representatives. Remember
               that any town hall has limited time, and a question you take is one less question for a constituent.</p>
 
             <p>For more, we recommend:</p>
             <ul>
               <li>Indivisible's
-                <a href="https://indivisible.org/resource/town-hall-guide" target="_blank">Town Hall strategy resources</a>
+                <a href="https://indivisible.org/resource/town-hall-guide" target="_blank">Town Hall strategy
+                  resources</a>
               </li>
             </ul>
           </div>
@@ -758,16 +805,20 @@
         <article class="row">
           <div class="col-sm-6">
             <h3>Why Town Halls</h3>
-            <p>There is no better way to influence your representatives than in-person conversations. Town halls are a longstanding
-              American tradition--where our elected representatives must listen and respond to the concerns of their constituents.
+            <p>There is no better way to influence your representatives than in-person conversations. Town halls are a
+              longstanding
+              American tradition--where our elected representatives must listen and respond to the concerns of their
+              constituents.
               Remember: you are their boss.</p>
-            <p>We believe every citizen, no matter the party of their members of Congress, should have the opportunity to speak
+            <p>We believe every citizen, no matter the party of their members of Congress, should have the opportunity
+              to speak
               with his or her representatives.</p>
             <p>You have more power than you think. Town halls are one of the most effective ways to use it.</p>
           </div>
           <div class="col-sm-6">
             <h3>Our Supporters</h3>
-            <p>Town Hall Project is possible because of the hard work of researchers, organizers, and developers across country,
+            <p>Town Hall Project is possible because of the hard work of researchers, organizers, and developers across
+              country,
               and the generous support of hundreds of grassroots donors.</p>
           </div>
         </article>
@@ -779,15 +830,17 @@
           <div class="panel panel-default">
             <div class="panel-heading" role="tab">
               <h4 class="panel-title">
-                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#canIJoin" aria-expanded="true" aria-controls="canIJoin">
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#canIJoin" aria-expanded="true"
+                  aria-controls="canIJoin">
                   Can I join you?
                 </a>
               </h4>
             </div>
             <div id="canIJoin" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="Can I Join You?">
               <div class="panel-body">
-                Yes! If you are interested in joining our volunteer research team or have more specialized skills like web development, contact
-                us at 
+                Yes! If you are interested in joining our volunteer research team or have more specialized skills like
+                web development, contact
+                us at
                 <a href="mailto:info@townhallproject.com">info@townhallproject.com</a>.
               </div>
             </div>
@@ -795,17 +848,20 @@
           <div class="panel panel-default">
             <div class="panel-heading" role="tab">
               <h4 class="panel-title">
-                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#canISupport" aria-expanded="true" aria-controls="canISupport">
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#canISupport"
+                  aria-expanded="true" aria-controls="canISupport">
                   Can I support you?
                 </a>
               </h4>
             </div>
             <div id="canISupport" class="panel-collapse collapse" role="tabpanel" aria-labelledby="Can I support you?">
               <div class="panel-body">
-                Yes! Town Hall Project relies on grassroots donations like yours to continue to bring rapid event research to citizens and
+                Yes! Town Hall Project relies on grassroots donations like yours to continue to bring rapid event
+                research to citizens and
                 activists nationwide. Please make a donation
-                <a href="https://secure.actblue.com/donate/thp" target="_blank">here</a>. If you are interested in a larger or ongoing donation, or represent a granting foundation, please
-                contact us at 
+                <a href="https://secure.actblue.com/donate/thp" target="_blank">here</a>. If you are interested in a
+                larger or ongoing donation, or represent a granting foundation, please
+                contact us at
                 <a href="mailto:info@townhallproject.com">info@townhallproject.com</a>.
               </div>
             </div>
@@ -813,26 +869,34 @@
           <div class="panel panel-default">
             <div class="panel-heading" role="tab">
               <h4 class="panel-title">
-                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#ourStory" aria-expanded="true" aria-controls="ourStory">
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#ourStory" aria-expanded="true"
+                  aria-controls="ourStory">
                   What’s your story?
                 </a>
               </h4>
             </div>
             <div id="ourStory" class="panel-collapse collapse" role="tabpanel" aria-labelledby="What's your story?">
               <div class="panel-body">
-                <p>At the beginning of 2017, our founder Jimmy Dahman believed that congressional town halls would play an enormously
-                  important role in this chapter of our democracy but was surprised to discover just how difficult information
+                <p>At the beginning of 2017, our founder Jimmy Dahman believed that congressional town halls would play
+                  an enormously
+                  important role in this chapter of our democracy but was surprised to discover just how difficult
+                  information
                   about these events was to find.</p>
 
-                <p>He recruited a small group of fellow organizers and activists who built a volunteer research team and began
-                  collecting these events in a google spreadsheet. Within days of launching we were completely overwhelmed
+                <p>He recruited a small group of fellow organizers and activists who built a volunteer research team and
+                  began
+                  collecting these events in a google spreadsheet. Within days of launching we were completely
+                  overwhelmed
                   by the intense public interest.</p>
 
-                <p>Throughout February, hundreds of thousands of people visited our spreadsheet--and then our quickly-built
-                  website--and tens of thousands attended congressional town halls. As Americans realized how the radical
+                <p>Throughout February, hundreds of thousands of people visited our spreadsheet--and then our
+                  quickly-built
+                  website--and tens of thousands attended congressional town halls. As Americans realized how the
+                  radical
                   agenda being discussed in the halls of Congress was, citizens began to make their voices heard.</p>
 
-                <p>Today we are proud to research and public events with members of Congress, opportunities for civic activism,
+                <p>Today we are proud to research and public events with members of Congress, opportunities for civic
+                  activism,
                   and other ways to Show Up and Speak Out. And there’s more to come...</p>
               </div>
             </div>
@@ -840,22 +904,30 @@
           <div class="panel panel-default">
             <div class="panel-heading" role="tab">
               <h4 class="panel-title">
-                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#politicalPerspective" aria-expanded="true" aria-controls="politicalPerspective">
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#politicalPerspective"
+                  aria-expanded="true" aria-controls="politicalPerspective">
                   What is your political perspective?
                 </a>
               </h4>
             </div>
-            <div id="politicalPerspective" class="panel-collapse collapse" role="tabpanel" aria-labelledby="What is your political perspective?">
+            <div id="politicalPerspective" class="panel-collapse collapse" role="tabpanel"
+              aria-labelledby="What is your political perspective?">
               <div class="panel-body">
-                <p>We are transparent that the Town Hall Project team shares largely progressive policy views. We make no secret
-                  of our support of other progressive organizations and our opposition to this Administration’s most extreme
+                <p>We are transparent that the Town Hall Project team shares largely progressive policy views. We make
+                  no secret
+                  of our support of other progressive organizations and our opposition to this Administration’s most
+                  extreme
                   policies.</p>
 
-                <p>But we don’t pull any punches with our research. We list every town hall held by Republicans, Democrats,
-                  and Independents. And we will call out “Missing Members” (those who refuse to hold town halls) of all parties.</p>
+                <p>But we don’t pull any punches with our research. We list every town hall held by Republicans,
+                  Democrats,
+                  and Independents. And we will call out “Missing Members” (those who refuse to hold town halls) of all
+                  parties.</p>
 
-                <p>We encourage all Americans, regardless of partisan leanings, to attend public events with your members of
-                  Congress and make your voice heard. From the bluest district to the reddest, and everything in between,
+                <p>We encourage all Americans, regardless of partisan leanings, to attend public events with your
+                  members of
+                  Congress and make your voice heard. From the bluest district to the reddest, and everything in
+                  between,
                   every single member of Congress will represent their constituents better by listening to them.</p>
               </div>
             </div>
@@ -863,12 +935,14 @@
           <div class="panel panel-default">
             <div class="panel-heading" role="tab">
               <h4 class="panel-title">
-                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#townhallcom" aria-expanded="true" aria-controls="townhallcom">
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#townhallcom"
+                  aria-expanded="true" aria-controls="townhallcom">
                   Are you affiliated with townhall.com?
                 </a>
               </h4>
             </div>
-            <div id="townhallcom" class="panel-collapse collapse" role="tabpanel" aria-labelledby="Are you affiliated with townhall.com?">
+            <div id="townhallcom" class="panel-collapse collapse" role="tabpanel"
+              aria-labelledby="Are you affiliated with townhall.com?">
               <div class="panel-body">
                 Nope.
               </div>
@@ -877,41 +951,47 @@
           <div class="panel panel-default">
             <div class="panel-heading" role="tab">
               <h4 class="panel-title">
-                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#whoAreYou" aria-expanded="true" aria-controls="whoAreYou">
+                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#whoAreYou" aria-expanded="true"
+                  aria-controls="whoAreYou">
                   Who are you?
                 </a>
               </h4>
             </div>
-            <div id="whoAreYou" class="panel-collapse collapse" role="tabpanel" aria-labelledby="Are you affiliated with whoAreYou?">
+            <div id="whoAreYou" class="panel-collapse collapse" role="tabpanel"
+              aria-labelledby="Are you affiliated with whoAreYou?">
               <div class="panel-body">
-                <p>Town Hall Project would not be possible without the hard work and talent of dozens of research volunteers,
+                <p>Town Hall Project would not be possible without the hard work and talent of dozens of research
+                  volunteers,
                   web developers, communications experts, and advisors.</p>
 
                 <p>Our leadership team:</p>
 
                 <p>
-                  Nathan Williams - Executive Director - Nathan co-founded Town Hall Project in 2017. 
-                  Previously Nathan worked on candidate and issue campaigns, including the 2008 Obama campaign. 
+                  Nathan Williams - Executive Director - Nathan co-founded Town Hall Project in 2017.
+                  Previously Nathan worked on candidate and issue campaigns, including the 2008 Obama campaign.
                   He is also an award-winning independent filmmaker.
                 </p>
 
                 <p>
-                  Megan Riel-Mehan - Lead Web Developer - Megan is a PhD chemical biologist and experienced web developer,
+                  Megan Riel-Mehan - Lead Web Developer - Megan is a PhD chemical biologist and experienced web
+                  developer,
                   currently specializing in visualizing cell biology at the Allen Institute in Seattle.
                 </p>
 
                 <p>
-                  Jenita Igwealor - National Organizing Director - Jenita has worked in politics and labor for over ten years, 
-                  including the 2008 and 2012 Obama campaigns. She has developed training programs for campaign staff and 
+                  Jenita Igwealor - National Organizing Director - Jenita has worked in politics and labor for over ten
+                  years,
+                  including the 2008 and 2012 Obama campaigns. She has developed training programs for campaign staff
+                  and
                   community activists interested in pay equity advocacy, civic engagement, and education affordability.
                 </p>
 
                 <p>
-                  Robert Castaneda - National Research Director - Before joining Town Hall Project, Robert has organized 
-                  electoral and issue campaigns from the local to national level. In 2016, he led a team of organizers 
+                  Robert Castaneda - National Research Director - Before joining Town Hall Project, Robert has organized
+                  electoral and issue campaigns from the local to national level. In 2016, he led a team of organizers
                   in Summit County, Ohio. Robert speaks 4 languages fluently.
                 </p>
-                
+
               </div>
             </div>
           </div>
@@ -922,22 +1002,26 @@
           <div class="col-sm-5 col-offset-1">
             <h3>Can I send you town halls that I find?</h3>
             <p>Yes! Please send town hall or any other congressional events to us
-              <a href="#submit">here</a>. Please include as much detail as you can, including a date, time, and link or other source of the
+              <a href="#submit">here</a>. Please include as much detail as you can, including a date, time, and link or
+              other source of the
               event information. </p>
           </div>
           <div class="col-sm-5 col-sm-offset-2">
             <h3>What if my representatives have no public events scheduled?</h3>
             <p>Call their
-              <a href="https://www.govtrack.us/congress/members" target="_blank">district offices</a> and let them know you expect them to hold public events with their constituents. To have
+              <a href="https://www.govtrack.us/congress/members" target="_blank">district offices</a> and let them know
+              you expect them to hold public events with their constituents. To have
               even more impact, join with other citizens in your district or state and organize group efforts. Visit the
-              district office together, deliver petitions, inform your local press, or even hold an “Empty Chair” town hall
+              district office together, deliver petitions, inform your local press, or even hold an “Empty Chair” town
+              hall
               and invite your member of Congress to fill that chair.</p>
           </div>
         </article>
         <article class="row text-center">
           <h3>Get connected locally!</h3>
           <p>
-            <a data-toggle="tab" class="hash-link" href="#contact">Contact us </a>and one of our organizers will connect you with groups in your area.</p>
+            <a data-toggle="tab" class="hash-link" href="#contact">Contact us </a>and one of our organizers will connect
+            you with groups in your area.</p>
           <a class="privacy-policy-button" data-toggle="tab" href="#privacy-policy">Privacy Policy</a>
         </article>
         <div class="col-sm-4">
@@ -946,10 +1030,14 @@
       <section class="container">
         <div class="row">
           <div class="col-sm-12" id="disclaimer">
-            <small>The information available on or from this website is compiled by Town Hall Project volunteers and provided for
-              general informational purposes only. While all efforts are made to verify accuracy of events, event details
-              can change at short notice and are not guaranteed to be complete or up-to-date. Please contact your representative’s
-              office to confirm. Town Hall Project shall not be liable for any special or consequential damages that result
+            <small>The information available on or from this website is compiled by Town Hall Project volunteers and
+              provided for
+              general informational purposes only. While all efforts are made to verify accuracy of events, event
+              details
+              can change at short notice and are not guaranteed to be complete or up-to-date. Please contact your
+              representative’s
+              office to confirm. Town Hall Project shall not be liable for any special or consequential damages that
+              result
               from the direct or indirect use of, or the inability to use, the information on this site.</small>
           </div>
         </div>
@@ -960,7 +1048,8 @@
         <section class="container container-fluid">
           <div class="col-md-6 col-md-offset-3">
             <p class="lead">Sign up now for personalized event updates for your congressional district and state! </p>
-            <p>We will email you town hall events with your members of Congress, as well as send the latest news on upcoming
+            <p>We will email you town hall events with your members of Congress, as well as send the latest news on
+              upcoming
               debates in Congress and updates on our project.</p>
           </div>
         </section>
@@ -979,7 +1068,8 @@
         <section class="container container-fluid">
           <div class="col-md-6 col-md-offset-3">
             <p class="lead">
-              <span id="mm-total-copy">Many</span> members of Congress have not held a single in-person town hall since January 3, 2019.
+              <span id="mm-total-copy">Many</span> members of Congress have not held a single in-person town hall since
+              January 3, 2019.
             </p>
             <p class="lead">
               Is yours one of them?
@@ -1009,22 +1099,24 @@
           </ul>
           <ul class="nav navbar-nav navbar-right btn-group">
             <li class="nav-item dropdown filter-button-group btn-group">
-              <a href="#" class="btn btn-xs dropdown-toggle navbar-btn btn-group mm-btn-group" data-toggle="dropdown" role="button" aria-haspopup="true"
-                aria-expanded="false">Party
+              <a href="#" class="btn btn-xs dropdown-toggle navbar-btn btn-group mm-btn-group" data-toggle="dropdown"
+                role="button" aria-haspopup="true" aria-expanded="false">Party
                 <span class="caret"></span>
               </a>
               <ul class="dropdown-menu button-group" data-filter-group="party">
                 <li class="downdown-title">Filter by party</li>
                 <li role="separator" class="divider"></li>
-                <li data-filter=".Democratic" id="Democratic" class="btn dropdown-item btn-filter btn-white">Democratic</li>
-                <li data-filter=".Republican" id="Republican" class="btn dropdown-item btn-filter btn-white">Republican</li>
+                <li data-filter=".Democratic" id="Democratic" class="btn dropdown-item btn-filter btn-white">Democratic
+                </li>
+                <li data-filter=".Republican" id="Republican" class="btn dropdown-item btn-filter btn-white">Republican
+                </li>
                 <!-- <li data-filter=".Independent" id="Independent" class="btn dropdown-item btn-filter btn-white">Independent</li> -->
                 <li data-filter="" id="All" class="btn dropdown-item btn-filter btn-white">All</li>
               </ul>
             </li>
             <li class=" nav-item dropdown filter-button-group btn-group">
-              <a href="#" class="btn btn-xs dropdown-toggle navbar-btn btn-group mm-btn-group" data-toggle="dropdown" role="button" aria-haspopup="true"
-                aria-expanded="false">Chamber
+              <a href="#" class="btn btn-xs dropdown-toggle navbar-btn btn-group mm-btn-group" data-toggle="dropdown"
+                role="button" aria-haspopup="true" aria-expanded="false">Chamber
                 <span class="caret"></span>
               </a>
               <ul class="dropdown-menu button-group" data-filter-group="chamber">
@@ -1062,7 +1154,8 @@
         <h1 class="text-primary text-center">Share your Town Hall Videos</h2>
           <div class="col-sm-8 col-sm-offset-2 upload-video-stage-1 text-center">
             <h3 class="margin-bottom">Have a video from a town hall you want to share?</h3>
-            <button class="btn btn-primary btn-lg btn-light-background upload-video-begin center-block">Click to begin uploading</button>
+            <button class="btn btn-primary btn-lg btn-light-background upload-video-begin center-block">Click to begin
+              uploading</button>
           </div>
           <div class="col-sm-8 col-sm-offset-2 upload-video-stage-2 hidden">
             <h3>Authorizing with youtube, please wait...</h3>
@@ -1074,17 +1167,21 @@
                 <input type="text" class="form-control" name="title" placeholder="Title (event and date)">
               </div>
               <div>
-                <textarea class="form-control" name="description" placeholder="Please tell us about any particularly powerful questions, answers or other moments--and the relevant timecode when possible"></textarea>
+                <textarea class="form-control" name="description"
+                  placeholder="Please tell us about any particularly powerful questions, answers or other moments--and the relevant timecode when possible"></textarea>
               </div>
               <div>
                 <input input type="file" id="video-file-field" class="button form-control" accept="video/*">
               </div>
               <div>
-                <em>By uploading a video you grant the Town Hall Project permission to use the video and share it with the public.
-                  You also certify that you own all rights to the content or that you are authorized by the owner to make
+                <em>By uploading a video you grant the Town Hall Project permission to use the video and share it with
+                  the public.
+                  You also certify that you own all rights to the content or that you are authorized by the owner to
+                  make
                   the content publicly available.</em>
               </div>
-              <button name="button" class="btn btn-primary btn-light-background btn-lg upload-video-upload" disabled="true">Upload my video</button>
+              <button name="button" class="btn btn-primary btn-light-background btn-lg upload-video-upload"
+                disabled="true">Upload my video</button>
             </form>
           </div>
           <div class="col-sm-8 col-sm-offset-2 upload-video-stage-4 hidden">
@@ -1101,7 +1198,8 @@
           </div>
           <div class="col-sm-8 col-sm-offset-2 upload-video-stage-5 hidden">
             <h3>Your video has been successfully uploaded. It will be reviewed by our team shortly. Thank you!</h3>
-            <button class="btn btn-primary btn-lg btn-light-background upload-video-begin center-block" id="upload-another">Upload another video</button>
+            <button class="btn btn-primary btn-lg btn-light-background upload-video-begin center-block"
+              id="upload-another">Upload another video</button>
           </div>
       </section>
     </div>
@@ -1115,89 +1213,143 @@
       </header>
       <section class="container ">
         <div class="col-sm-10 col-sm-offset-1">
-          <p>This website, application or online tool is operated by Town Hall Project (“Town Hall Project”, “we” or “us”).
-            This privacy policy (“Policy”) explains how personal information is collected, used, and disclosed by Town Hall
-            Project with respect to your use of the townhallproject.com web site and other Town Hall Project or co-branded
-            web sites, applications, online tools and other online products or services which link to this Policy (the “Sites”)
-            so you can make an informed decision about using the Sites. We value your privacy and endeavor to provide you
+          <p>This website, application or online tool is operated by Town Hall Project (“Town Hall Project”, “we” or
+            “us”).
+            This privacy policy (“Policy”) explains how personal information is collected, used, and disclosed by Town
+            Hall
+            Project with respect to your use of the townhallproject.com web site and other Town Hall Project or
+            co-branded
+            web sites, applications, online tools and other online products or services which link to this Policy (the
+            “Sites”)
+            so you can make an informed decision about using the Sites. We value your privacy and endeavor to provide
+            you
             with a safe and secure user experience.</p>
-          <p>This website is operated by Town Hall Project. We are not performing any services on behalf of any member of the
-            United States Congress or their offices. This website and tools are operated by Town Hall Project to help you
+          <p>This website is operated by Town Hall Project. We are not performing any services on behalf of any member
+            of the
+            United States Congress or their offices. This website and tools are operated by Town Hall Project to help
+            you
             more easily connect with your elected representatives and better engage in the democratic process.</p>
-          <p>We reserve the right to change the provisions of this Policy at any time. We will alert you that changes have been
-            made by indicating on the Policy the date it was last updated. We encourage you to review this Policy from time
+          <p>We reserve the right to change the provisions of this Policy at any time. We will alert you that changes
+            have been
+            made by indicating on the Policy the date it was last updated. We encourage you to review this Policy from
+            time
             to time to make sure that you understand how any personal information you provide will be used.</p>
           <h3>What Personal Information Do We Collect?</h3>
-          <p>Active Collection: Personal information may be collected in a number of ways when you visit our Sites. We collect
+          <p>Active Collection: Personal information may be collected in a number of ways when you visit our Sites. We
+            collect
             certain information you voluntarily provide to us, such as if you join our email list, make a donation, fill
-            out a form, connect through a social feed, sign up to be a volunteer, use a tool on a Site or request information.
-            Such information may include personal information, such as your name, mailing address, email address, phone number,
-            and credit card information. We may also collect demographic information you may voluntarily provide from time
-            to time, such as in response to questionnaires, surveys, and interactive tools such as calculators, including
+            out a form, connect through a social feed, sign up to be a volunteer, use a tool on a Site or request
+            information.
+            Such information may include personal information, such as your name, mailing address, email address, phone
+            number,
+            and credit card information. We may also collect demographic information you may voluntarily provide from
+            time
+            to time, such as in response to questionnaires, surveys, and interactive tools such as calculators,
+            including
             gender, ethnicity, education, income and interest information.</p>
-          <p>If this information is tied to personally identifiable information, it will be treated as personal information.
-            Personal and demographic information may also be collected if you provide such information in connection with
-            creating a profile or group, leaving comments, posting social media comments or other content, sending an email
-            or message to another user, or participating in any interactive forums or features on the Sites. In addition,
-            from time to time we may collect demographic, contact or other personal information you provide in connection
+          <p>If this information is tied to personally identifiable information, it will be treated as personal
+            information.
+            Personal and demographic information may also be collected if you provide such information in connection
+            with
+            creating a profile or group, leaving comments, posting social media comments or other content, sending an
+            email
+            or message to another user, or participating in any interactive forums or features on the Sites. In
+            addition,
+            from time to time we may collect demographic, contact or other personal information you provide in
+            connection
             with your participation in surveys, sweepstakes, games, promotions and other activities on the Sites. We may
-            also obtain information from other sources and combine that with information we collect on our Sites. This information
+            also obtain information from other sources and combine that with information we collect on our Sites. This
+            information
             is not stored with any personally identifiable information you voluntarily provide.</p>
-          <p>Passive Collection: When you use the Sites, some information is also automatically collected, such as your Internet
+          <p>Passive Collection: When you use the Sites, some information is also automatically collected, such as your
+            Internet
             Protocol (IP) address, your operating system, the browser type, pages viewed, the address of a referring web
-            site, and your activity on our Sites. If you access the Sites from a mobile device, we may also collect information
-            about the type of mobile device you use and the type of mobile Internet browsers you use. We treat this information
-            as personal information if we combine it with or link it to any of the identifying information mentioned above.
+            site, and your activity on our Sites. If you access the Sites from a mobile device, we may also collect
+            information
+            about the type of mobile device you use and the type of mobile Internet browsers you use. We treat this
+            information
+            as personal information if we combine it with or link it to any of the identifying information mentioned
+            above.
             Otherwise, it is used in the aggregate only.</p>
-          <p>We may also automatically collect certain information through the use of “cookies” or web beacons. Cookies are
-            small data files stored on your hard drive at the request of a website. Among other things, cookies help us improve
-            our Sites and your experience. Information obtained from cookies and linked to personally identifying information
-            is treated as personal information. If you wish to block, erase, or be warned of cookies, please refer to your
-            browser manufacturer to learn about these functions. However, if you choose to remove or reject browser cookies,
+          <p>We may also automatically collect certain information through the use of “cookies” or web beacons. Cookies
+            are
+            small data files stored on your hard drive at the request of a website. Among other things, cookies help us
+            improve
+            our Sites and your experience. Information obtained from cookies and linked to personally identifying
+            information
+            is treated as personal information. If you wish to block, erase, or be warned of cookies, please refer to
+            your
+            browser manufacturer to learn about these functions. However, if you choose to remove or reject browser
+            cookies,
             this could affect certain features on our Sites. Web beacons are small, invisible graphic images that may be
-            used on the Sites or in emails relating to the Sites to collect certain information about usage and program effectiveness
+            used on the Sites or in emails relating to the Sites to collect certain information about usage and program
+            effectiveness
             and monitor user activity on the Sites.</p>
-          <p>Advertising and Analytics Services Provided by Others. We may allow others to serve advertisements on our behalf
+          <p>Advertising and Analytics Services Provided by Others. We may allow others to serve advertisements on our
+            behalf
             across the Internet and to provide analytics services. These entities may use cookies, web beacons and other
-            technologies to collect information about your use of the Sites and other websites, including your IP address,
-            web browser, pages viewed, time spent on pages, links clicked and conversion information. This information may
-            be used by Town Hall Project and others to, among other things, analyze and track data, determine the popularity
-            of certain content, deliver advertising and content targeted to your interests on the Sites and other websites,
-            and better understand your online activity. For more information about Internet-based ads, or to opt out of having
+            technologies to collect information about your use of the Sites and other websites, including your IP
+            address,
+            web browser, pages viewed, time spent on pages, links clicked and conversion information. This information
+            may
+            be used by Town Hall Project and others to, among other things, analyze and track data, determine the
+            popularity
+            of certain content, deliver advertising and content targeted to your interests on the Sites and other
+            websites,
+            and better understand your online activity. For more information about Internet-based ads, or to opt out of
+            having
             your web browsing information used for behavioral advertising purposes, please visit
             <a href="www.networkadvertising.org/managing/opt_out.asp">Network Advertising</a> and
             <a href="www.aboutads.info/choices">About Ads</a>.</p>
           <h4>What Personal Information Do We Share With Third Parties?</h4>
-          <p>It is our policy not to share the personal information we collect from you through our Sites with third parties,
-            except as described in this Policy or as otherwise disclosed on the Sites. For example, we may share personal
+          <p>It is our policy not to share the personal information we collect from you through our Sites with third
+            parties,
+            except as described in this Policy or as otherwise disclosed on the Sites. For example, we may share
+            personal
             information as follows:</p>
           <ul>
-            <li>with vendors, consultants, and other service providers or volunteers who are engaged by or working with us and
+            <li>with vendors, consultants, and other service providers or volunteers who are engaged by or working with
+              us and
               who need access to such information to carry out their work for us;</li>
-            <li>with organizations, groups or causes that we believe have similar viewpoints, principles, activities or objectives;</li>
-            <li>when you give us your consent to do so, including if we notify you on the Sites, that the information you provide
+            <li>with organizations, groups or causes that we believe have similar viewpoints, principles, activities or
+              objectives;</li>
+            <li>when you give us your consent to do so, including if we notify you on the Sites, that the information
+              you provide
               will be shared or used in a particular manner and you provide such information;</li>
-            <li>when you register to get connected locally, the information you provide to Town Hall Project and our organizers
+            <li>when you register to get connected locally, the information you provide to Town Hall Project and our
+              organizers
               may be shared with Town Hall Project’s partner organizations;</li>
-            <li>when we are operating a co-branded site, application or tool, we may share the information you provide with the
+            <li>when we are operating a co-branded site, application or tool, we may share the information you provide
+              with the
               party with whom we are co-branding;</li>
-            <li>when we believe in good faith that we are lawfully authorized or required to do so or that doing so is reasonably
-              necessary or appropriate to comply with the law or legal processes or respond to lawful requests, claims or
+            <li>when we believe in good faith that we are lawfully authorized or required to do so or that doing so is
+              reasonably
+              necessary or appropriate to comply with the law or legal processes or respond to lawful requests, claims
+              or
               legal authorities, including responding to lawful subpoenas, warrants, or court orders;</li>
-            <li>when we believe in good faith that doing so is reasonably necessary or appropriate to respond to claims or to
-              protect the rights, property, or safety of Town Hall Project, our users, our employees, our volunteers, copyright
+            <li>when we believe in good faith that doing so is reasonably necessary or appropriate to respond to claims
+              or to
+              protect the rights, property, or safety of Town Hall Project, our users, our employees, our volunteers,
+              copyright
               owners, third parties or the public, including without limitation to protect such parties from fraudulent,
               abusive, inappropriate, or unlawful activity or use of our Site;</li>
             <li>to enforce or apply this Policy, our Terms of Service, or our other policies or agreements; and</li>
-            <li> in connection with, or during negotiations of, any merger, reorganization, acquisition, asset sale, financing
-              or lending transaction or in any other situation where personal information may be disclosed or transferred
+            <li> in connection with, or during negotiations of, any merger, reorganization, acquisition, asset sale,
+              financing
+              or lending transaction or in any other situation where personal information may be disclosed or
+              transferred
               as one of the assets of Town Hall Project.</li>
           </ul>
-          <p>We are not responsible for the actions of any service providers or other third parties, nor are we responsible
-            for any additional information you provide directly to any third parties, and we encourage you to become familiar
-            with their privacy practices before disclosing information directly to any such parties. Nothing herein restricts
-            the sharing of aggregated or anonymized information, which may be shared with third parties without your consent.</p>
-          <p>Town Hall Project is volunteer driven and your experience is important to us. If you have any questions or concerns,
+          <p>We are not responsible for the actions of any service providers or other third parties, nor are we
+            responsible
+            for any additional information you provide directly to any third parties, and we encourage you to become
+            familiar
+            with their privacy practices before disclosing information directly to any such parties. Nothing herein
+            restricts
+            the sharing of aggregated or anonymized information, which may be shared with third parties without your
+            consent.</p>
+          <p>Town Hall Project is volunteer driven and your experience is important to us. If you have any questions or
+            concerns,
             please feel free to
             <a data-toggle="tab" class="hash-link" href="#contact">contact us</a>.</p>
         </div>
@@ -1241,27 +1393,30 @@
     <div class="modal-dialog modal-md" role="document">
       <div class="modal-content">
         <img src="/Images/Missing_Member_Report.png" alt="" />
-        <a class="twitter-share-button" href="https://townhallproject.com/Images/Missing_Member_Report.png?text=Missing%20Members%20Report">
+        <a class="twitter-share-button"
+          href="https://townhallproject.com/Images/Missing_Member_Report.png?text=Missing%20Members%20Report">
           Tweet</a>
-        <iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftownhallproject.com%2FImages%2FMissing_Member_Report.png&layout=button&size=small&mobile_iframe=true&appId=1549118422076809&width=59&height=20"
-          width="59" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>
+        <iframe
+          src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftownhallproject.com%2FImages%2FMissing_Member_Report.png&layout=button&size=small&mobile_iframe=true&appId=1549118422076809&width=59&height=20"
+          width="59" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0"
+          allowTransparency="true"></iframe>
       </div>
     </div>
   </div>
-    <div class="modal fade recess-report-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
-      <div class="modal-dialog modal-md" role="document">
-        <div class="modal-content">
-          <img src="/Images/report-2019.png" alt="" />
-          <a class="twitter-share-button"
-            href="https://townhallproject.com/Images/report-2019.png?text=AccessibilityReport">
-            Tweet</a>
-          <iframe
-            src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftownhallproject.com%2FImages%2Freport-2019.png&layout=button&size=small&mobile_iframe=true&appId=1549118422076809&width=59&height=20"
-            width="59" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0"
-            allowTransparency="true"></iframe>
-        </div>
+  <div class="modal fade recess-report-modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
+    <div class="modal-dialog modal-md" role="document">
+      <div class="modal-content">
+        <img src="/Images/report-2019.png" alt="" />
+        <a class="twitter-share-button"
+          href="https://townhallproject.com/Images/report-2019.png?text=AccessibilityReport">
+          Tweet</a>
+        <iframe
+          src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2Ftownhallproject.com%2FImages%2Freport-2019.png&layout=button&size=small&mobile_iframe=true&appId=1549118422076809&width=59&height=20"
+          width="59" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0"
+          allowTransparency="true"></iframe>
       </div>
     </div>
+  </div>
   <footer class="footer">
     <div class="container text-center">
       <ul class="list-unstyled">
@@ -1344,7 +1499,7 @@
     }(document, "script", "twitter-wjs"));
   </script>
   <!-- Script Files -->
-  
+
   <script src="/scripts/lib/firebasedb.js"></script>
   <script src="/scripts/lib/map-helper-functions.js"></script>
   <script src="/scripts/lib/urlParams.js"></script>
@@ -1381,7 +1536,8 @@
   <script src="/scripts/controllers/map-controller.js"></script>
   <script src="/scripts/controllers/routes.js"></script>
 
-  <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDQqJSJk6FsBRCtT3scm49ShAB5zZDFAys&callback=initMap&libraries=visualization,geometry"></script>
+  <script async defer
+    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDQqJSJk6FsBRCtT3scm49ShAB5zZDFAys&callback=initMap&libraries=visualization,geometry"></script>
 
 </body>
 


### PR DESCRIPTION
Tempoary Fix to issue #473 
Adds < style="display:none" > to the div holding the opt in email checkbox. 
The effect is that users will no longer be able to access the checkbox and every 'person' object that gets saved to the database will be saved as though they had left the checkbox blank. 

A more comprehensive fix would require refactoring emailSignUpView.js to no longer use the 'partner' form field at all.

