### PR TITLE
Added Other to the defaultSearchFilter, need to fix meetingType

### DIFF
--- a/src/components/Home/EventsTable/eventsConstants.js
+++ b/src/components/Home/EventsTable/eventsConstants.js
@@ -42,6 +42,7 @@ export const searchFilters = {
   sortOn: ['Date', 'State', 'Name']
 }
 
+// TODO: Having no filters should not hide the data. 
 export const defaultSearchFilters = {
   party: ['Democratic', 'Republican', 'Independent'],
   meetingType: [
@@ -49,7 +50,8 @@ export const defaultSearchFilters = {
     'Empty Chair Town Hall',
     'Campaign Town Hall',
     'Youth Vote',
-    'Voting Rights'
+    'Voting Rights',
+    'Other'
   ],
   sortOn: 'Date'
 }


### PR DESCRIPTION
Description
Found out that removing all MeetingTypes in the defaultSearchFilters array removes all event data. Need to fix this. Also, added 'Other' to the defaultSearchFilters array. 

Fixes #483 Display All Events in default setting on table 

Visual Change? No
