### PR TITLE
Photocredit is moved so it is 12px from the bottom 

### DIFF
--- a/src/styles/customboot.less
+++ b/src/styles/customboot.less
@@ -1280,7 +1280,7 @@ li[data-toggle='popover']:hover {
 .photo-credit{
   position: absolute;
   right: 20px;
-  bottom: 127px;
+  bottom: 12px;
 }
 
 img.grayscale {


### PR DESCRIPTION
@nathanmwilliams
Description
The photo credit text was moved closer to the bottom-right (12px from the bottom)

Fix #663 Update ‘photo cred’ positioning 

Visual Change? Yes 
![photo-credit-before](https://user-images.githubusercontent.com/8636027/76379420-40bbde00-630d-11ea-9835-d6fd195041a8.png)
![photo-credit-after](https://user-images.githubusercontent.com/8636027/76379434-49141900-630d-11ea-9f25-e6831c53ec40.png)


