### PR TITLE
Update banner language

### DIFF
--- a/src/components/Home/EventsWarningBanner/index.jsx
+++ b/src/components/Home/EventsWarningBanner/index.jsx
@@ -5,13 +5,10 @@ const EventsWarningBanner = () => {
   return (
     <div className="warningBanner">
       <p>
-        Face-to-face conversations between Americans and their lawmakers are vital for our democracy.
+      Based on the recommendations from health experts, we strongly encourage all lawmakers to suspend in-person town halls and any other public gatherings.
       </p>
       <p>
-        At the same time, we encourage everyone to follow the most up-to-date CDC public health guidelines. We are updating events as rapidly as possible as we learn of postponements, rescheduling, or shifts to virtual meetings.
-      </p>
-      <p>
-        We strongly encourage all lawmakers to continue to find ways to stay in contact with their constituents.
+      We encourage all Americans to avoid large group gatherings at this time. We will track and highlight as many telephone and virtual meetings as possible.
       </p>
     </div>
   )


### PR DESCRIPTION
Update events warning banner language from

<img width="1323" alt="Screen Shot 2020-03-15 at 11 41 45 AM" src="https://user-images.githubusercontent.com/44733961/76708163-fe4e2480-66b1-11ea-99ce-3f9bc6781105.png">

to:

![Screen Shot 2020-03-15 at 11 40 28 AM](https://user-images.githubusercontent.com/44733961/76708140-d3fc6700-66b1-11ea-9fc0-4bc704c268ca.png)

@nathanmwilliams @meganrm 
