### PR TITLE
Add tele-town hall to default events filter

### DIFF
--- a/src/components/Home/EventsTable/eventsConstants.js
+++ b/src/components/Home/EventsTable/eventsConstants.js
@@ -49,7 +49,8 @@ export const defaultSearchFilters = {
     'Empty Chair Town Hall',
     'Campaign Town Hall',
     'Youth Vote',
-    'Voting Rights'
+    'Voting Rights',
+    'Tele-Town Hall'
   ],
   sortOn: 'Date'
 }


### PR DESCRIPTION
Adds Tele-Town Hall to the default event filter on the events table. 

Fixes Issue #680 

@nathanmwilliams @meganrm 
