### PR TITLE
Add Campaign Tele-Town Hall to event table constants

### DIFF
--- a/src/components/Home/EventsTable/eventsConstants.js
+++ b/src/components/Home/EventsTable/eventsConstants.js
@@ -30,6 +30,9 @@ export const searchFilters = {
       description: 'A town hall conducted by conference call or online.'
     },
     {
+      type: 'Campaign Tele-Town Hall'
+    },
+    {
       type: 'Youth Vote'
     },
     {


### PR DESCRIPTION
Pairs with https://github.com/townhallproject/townHallSubmission/pull/78
Adds the newly created Campaign Tele-Town Hall category to events table filter.

Fixes #682 
