### PR TITLE
Create MutualAidHubBanner

### DIFF
--- a/src/components/Home/MutualAidHubBanner/index.jsx
+++ b/src/components/Home/MutualAidHubBanner/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const MutualAidHubBanner = (props) => {
+  return (
+    <div className="time-sensitive">
+      <div className="display-flex">
+        <div className="happening-now-title">
+          <h1><span className="break">Support local</span><span className="break"> communities</span></h1>
+          <h1><i className="fa fa-chevron-right"></i></h1>
+        </div>
+        <div className="happening-now-content">
+          <div className="text-center">
+            <h3 className="text-primary">
+              <a
+                target="_blank"
+                href="https://www.mutualaidhub.org/"
+              >
+                Across the country Americans are organizing Mutual Aid Networks to support their neighbors in need. Find community support efforts near you at mutualaidhub.org.
+              </a>
+            </h3>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+};
+
+export default MutualAidHubBanner;

--- a/src/components/Home/MutualAidHubBanner/index.jsx
+++ b/src/components/Home/MutualAidHubBanner/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const MutualAidHubBanner = (props) => {
   return (
-    <div className="time-sensitive">
+    <div className="time-sensitive background-gray">
       <div className="display-flex">
         <div className="happening-now-title">
           <h1><span className="break">Support local</span><span className="break"> communities</span></h1>

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -126,12 +126,12 @@ export default class Home extends React.Component {
     const usState = Home.getStateAbr(isState(this.props.location));
     return (
       <React.Fragment>
+        <MutualAidHubBanner />
         <ZipSearchComponent 
           usState={usState}
           setDistrict={this.setDistrict}
           setZip={this.setZip}
         />
-        <MutualAidHubBanner />
         {/*Call to action when no events are present*/}
         <NoEventsComponent />
         <MapComponent 

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -13,6 +13,7 @@ import EmailSignup from './EmailSignup';
 import RepresentativeCards from './RepresentativeCards';
 import EventsTable from './EventsTable';
 import EventModal from './EventModal';
+import MutualAidHubBanner from './MutualAidHubBanner'
 import { isState } from '../../utils';
 
 export default class Home extends React.Component {
@@ -130,6 +131,7 @@ export default class Home extends React.Component {
           setDistrict={this.setDistrict}
           setZip={this.setZip}
         />
+        <MutualAidHubBanner />
         {/*Call to action when no events are present*/}
         <NoEventsComponent />
         <MapComponent 

--- a/src/styles/customboot.less
+++ b/src/styles/customboot.less
@@ -800,7 +800,7 @@ a.social-icon {
     color: white;
     height: 100%;
     flex: 1;
-    padding-left: 20px;
+    padding: 5px 0px 5px 20px;
   }
   .happening-now-content {
     flex: 2;


### PR DESCRIPTION
Creates new banner, based off of What's happening now banner, to direct site visitors to Mutual Aid Hub.

Fixes #685 

<img width="1440" alt="Screen Shot 2020-04-14 at 2 51 13 PM" src="https://user-images.githubusercontent.com/44733961/79277925-9b41e000-7e5f-11ea-8f6e-300861bfa3bd.png">

@nathanmwilliams @meganrm 
# EDIT

Banner moved to top of the page with a gray background:
![Screen Shot 2020-04-20 at 6 42 20 PM](https://user-images.githubusercontent.com/44733961/79815987-eadc4c00-8336-11ea-8232-b81c898d6762.png)
