### PR TITLE
fix privacy policy text

### DIFF
--- a/src/components/PrivacyPolicyComponent/index.js
+++ b/src/components/PrivacyPolicyComponent/index.js
@@ -12,145 +12,126 @@ const PrivacyPolicyComponent = (props) => {
       </header>
       <section className="container ">
         <div className="col-sm-10 col-sm-offset-1">
-          <p>This website, application or online tool is operated by Town Hall Project (“Town Hall Project”, “we” or
-            “us”).
-            This privacy policy (“Policy”) explains how personal information is collected, used, and disclosed by Town
-            Hall
+          <p>
+            This website, application or online tool is operated by Town Hall Project (“Town Hall Project”, “we” or
+            “us”). This privacy policy (“Policy”) explains how personal information is collected, used, and disclosed by Town Hall
             Project with respect to your use of the townhallproject.com web site and other Town Hall Project or
-            co-branded
-            web sites, applications, online tools and other online products or services which link to this Policy (the
-            “Sites”)
-            so you can make an informed decision about using the Sites. We value your privacy and endeavor to provide
-            you
-              with a safe and secure user experience.</p>
-          <p>This website is operated by Town Hall Project. We are not performing any services on behalf of any member
-            of the
-            United States Congress or their offices. This website and tools are operated by Town Hall Project to help
-            you
-              more easily connect with your elected representatives and better engage in the democratic process.</p>
-          <p>We reserve the right to change the provisions of this Policy at any time. We will alert you that changes
-            have been
-            made by indicating on the Policy the date it was last updated. We encourage you to review this Policy from
-            time
-              to time to make sure that you understand how any personal information you provide will be used.</p>
+            co-branded web sites, applications, online tools and other online products or services which link to this Policy (the
+            “Sites”) so you can make an informed decision about using the Sites. We value your privacy and endeavor to provide
+            you with a safe and secure user experience.
+          </p>
+          <p>
+            This website is operated by Town Hall Project. We are not performing any services on behalf of any member
+            of the United States Congress or their offices. This website and tools are operated by Town Hall Project to help
+            you more easily connect with your elected representatives and better engage in the democratic process.
+          </p>
+          <p>
+            We reserve the right to change the provisions of this Policy at any time. We will alert you that changes
+            have been made by indicating on the Policy the date it was last updated. We encourage you to review this Policy from
+            time to time to make sure that you understand how any personal information you provide will be used.
+          </p>
           <h3>What Personal Information Do We Collect?</h3>
-          <p>Active Collection: Personal information may be collected in a number of ways when you visit our Sites. We
-            collect
-            certain information you voluntarily provide to us, such as if you join our email list, make a donation, fill
+          <p>
+            Active Collection: Personal information may be collected in a number of ways when you visit our Sites. We
+            collect certain information you voluntarily provide to us, such as if you join our email list, make a donation, fill
             out a form, connect through a social feed, sign up to be a volunteer, use a tool on a Site or request
-            information.
-            Such information may include personal information, such as your name, mailing address, email address, phone
-            number,
-            and credit card information. We may also collect demographic information you may voluntarily provide from
-            time
-            to time, such as in response to questionnaires, surveys, and interactive tools such as calculators,
-            including
-              gender, ethnicity, education, income and interest information.</p>
-          <p>If this information is tied to personally identifiable information, it will be treated as personal
-            information.
-            Personal and demographic information may also be collected if you provide such information in connection
-            with
-            creating a profile or group, leaving comments, posting social media comments or other content, sending an
-            email
-            or message to another user, or participating in any interactive forums or features on the Sites. In
-            addition,
-            from time to time we may collect demographic, contact or other personal information you provide in
-            connection
-            with your participation in surveys, sweepstakes, games, promotions and other activities on the Sites. We may
+            information. Such information may include personal information, such as your name, mailing address, email address, phone
+            number, and credit card information. We may also collect demographic information you may voluntarily provide from
+            time to time, such as in response to questionnaires, surveys, and interactive tools such as calculators,
+            including gender, ethnicity, education, income and interest information.
+          </p>
+          <p>
+            If this information is tied to personally identifiable information, it will be treated as personal
+            information. Personal and demographic information may also be collected if you provide such information in connection
+            with creating a profile or group, leaving comments, posting social media comments or other content, sending an
+            email or message to another user, or participating in any interactive forums or features on the Sites. In
+            addition, from time to time we may collect demographic, contact or other personal information you provide in
+            connection with your participation in surveys, sweepstakes, games, promotions and other activities on the Sites. We may
             also obtain information from other sources and combine that with information we collect on our Sites. This
-            information
-              is not stored with any personally identifiable information you voluntarily provide.</p>
+            information is not stored with any personally identifiable information you voluntarily provide.
+          </p>
           <p>Passive Collection: When you use the Sites, some information is also automatically collected, such as your
-            Internet
-            Protocol (IP) address, your operating system, the browser type, pages viewed, the address of a referring web
+            Internet Protocol (IP) address, your operating system, the browser type, pages viewed, the address of a referring web
             site, and your activity on our Sites. If you access the Sites from a mobile device, we may also collect
-            information
-            about the type of mobile device you use and the type of mobile Internet browsers you use. We treat this
-            information
-            as personal information if we combine it with or link it to any of the identifying information mentioned
-            above.
-              Otherwise, it is used in the aggregate only.</p>
-          <p>We may also automatically collect certain information through the use of “cookies” or web beacons. Cookies
-            are
-            small data files stored on your hard drive at the request of a website. Among other things, cookies help us
-            improve
-            our Sites and your experience. Information obtained from cookies and linked to personally identifying
-            information
-            is treated as personal information. If you wish to block, erase, or be warned of cookies, please refer to
-            your
-            browser manufacturer to learn about these functions. However, if you choose to remove or reject browser
-            cookies,
-            this could affect certain features on our Sites. Web beacons are small, invisible graphic images that may be
+            information about the type of mobile device you use and the type of mobile Internet browsers you use. We treat this
+            information as personal information if we combine it with or link it to any of the identifying information mentioned
+            above. Otherwise, it is used in the aggregate only.
+          </p>
+          <p>
+            We may also automatically collect certain information through the use of “cookies” or web beacons. Cookies
+            are small data files stored on your hard drive at the request of a website. Among other things, cookies help us
+            improve our Sites and your experience. Information obtained from cookies and linked to personally identifying
+            information is treated as personal information. If you wish to block, erase, or be warned of cookies, please refer to
+            your browser manufacturer to learn about these functions. However, if you choose to remove or reject browser
+            cookies, this could affect certain features on our Sites. Web beacons are small, invisible graphic images that may be
             used on the Sites or in emails relating to the Sites to collect certain information about usage and program
-            effectiveness
-              and monitor user activity on the Sites.</p>
+            effectiveness and monitor user activity on the Sites.
+          </p>
           <p>Advertising and Analytics Services Provided by Others. We may allow others to serve advertisements on our
-            behalf
-            across the Internet and to provide analytics services. These entities may use cookies, web beacons and other
+            behalf across the Internet and to provide analytics services. These entities may use cookies, web beacons and other
             technologies to collect information about your use of the Sites and other websites, including your IP
-            address,
-            web browser, pages viewed, time spent on pages, links clicked and conversion information. This information
-            may
-            be used by Town Hall Project and others to, among other things, analyze and track data, determine the
-            popularity
-            of certain content, deliver advertising and content targeted to your interests on the Sites and other
-            websites,
-            and better understand your online activity. For more information about Internet-based ads, or to opt out of
-            having
-            your web browsing information used for behavioral advertising purposes, please visit
-              <a href="www.networkadvertising.org/managing/opt_out.asp">Network Advertising</a> and
-              <a href="www.aboutads.info/choices">About Ads</a>.</p>
+            address, web browser, pages viewed, time spent on pages, links clicked and conversion information. This information
+            may be used by Town Hall Project and others to, among other things, analyze and track data, determine the
+            popularity of certain content, deliver advertising and content targeted to your interests on the Sites and other
+            websites, and better understand your online activity. 
+          </p>
           <h4>What Personal Information Do We Share With Third Parties?</h4>
-          <p>It is our policy not to share the personal information we collect from you through our Sites with third
-            parties,
-            except as described in this Policy or as otherwise disclosed on the Sites. For example, we may share
-            personal
-              information as follows:</p>
+          <p>
+            It is our policy not to share the personal information we collect from you through our Sites with third
+            parties, except as described in this Policy or as otherwise disclosed on the Sites. For example, we may share
+            personal information as follows:
+          </p>
           <ul>
-            <li>with vendors, consultants, and other service providers or volunteers who are engaged by or working with
-              us and
-                who need access to such information to carry out their work for us;</li>
-            <li>with organizations, groups or causes that we believe have similar viewpoints, principles, activities or
-                objectives;</li>
-            <li>when you give us your consent to do so, including if we notify you on the Sites, that the information
-              you provide
-                will be shared or used in a particular manner and you provide such information;</li>
-            <li>when you register to get connected locally, the information you provide to Town Hall Project and our
-              organizers
-                may be shared with Town Hall Project’s partner organizations;</li>
-            <li>when we are operating a co-branded site, application or tool, we may share the information you provide
-              with the
-                party with whom we are co-branding;</li>
-            <li>when we believe in good faith that we are lawfully authorized or required to do so or that doing so is
-              reasonably
-              necessary or appropriate to comply with the law or legal processes or respond to lawful requests, claims
-              or
-                legal authorities, including responding to lawful subpoenas, warrants, or court orders;</li>
-            <li>when we believe in good faith that doing so is reasonably necessary or appropriate to respond to claims
-              or to
-              protect the rights, property, or safety of Town Hall Project, our users, our employees, our volunteers,
-              copyright
-              owners, third parties or the public, including without limitation to protect such parties from fraudulent,
-                abusive, inappropriate, or unlawful activity or use of our Site;</li>
-            <li>to enforce or apply this Policy, our Terms of Service, or our other policies or agreements; and</li>
-            <li> in connection with, or during negotiations of, any merger, reorganization, acquisition, asset sale,
-              financing
-              or lending transaction or in any other situation where personal information may be disclosed or
-              transferred
-                as one of the assets of Town Hall Project.</li>
+            <li>
+              with vendors, consultants, and other service providers or volunteers who are engaged by or working with
+              us and who need access to such information to carry out their work for us;
+            </li>
+            <li>
+              with organizations, groups or causes that we believe have similar viewpoints, principles, activities or
+              objectives;
+            </li>
+            <li>
+              when you give us your consent to do so, including if we notify you on the Sites, that the information
+              you provide will be shared or used in a particular manner and you provide such information;
+            </li>
+            <li>
+              when you register to get connected locally, the information you provide to Town Hall Project and our
+              organizers may be shared with Town Hall Project’s partner organizations;
+            </li>
+            <li>
+              when we are operating a co-branded site, application or tool, we may share the information you provide
+              with the party with whom we are co-branding;
+            </li>
+            <li>
+              when we believe in good faith that we are lawfully authorized or required to do so or that doing so is
+              reasonably necessary or appropriate to comply with the law or legal processes or respond to lawful requests, claims
+              or legal authorities, including responding to lawful subpoenas, warrants, or court orders;
+            </li>
+            <li>
+              when we believe in good faith that doing so is reasonably necessary or appropriate to respond to claims
+              or to protect the rights, property, or safety of Town Hall Project, our users, our employees, our volunteers,
+              copyright owners, third parties or the public, including without limitation to protect such parties from fraudulent,
+              abusive, inappropriate, or unlawful activity or use of our Site;
+            </li>
+            <li>
+              to enforce or apply this Policy, our Terms of Service, or our other policies or agreements; and
+            </li>
+            <li> 
+              in connection with, or during negotiations of, any merger, reorganization, acquisition, asset sale,
+              financing or lending transaction or in any other situation where personal information may be disclosed or
+              transferred as one of the assets of Town Hall Project.
+            </li>
           </ul>
-          <p>We are not responsible for the actions of any service providers or other third parties, nor are we
-            responsible
-            for any additional information you provide directly to any third parties, and we encourage you to become
-            familiar
-            with their privacy practices before disclosing information directly to any such parties. Nothing herein
-            restricts
-            the sharing of aggregated or anonymized information, which may be shared with third parties without your
-              consent.</p>
-          <p>Town Hall Project is volunteer driven and your experience is important to us. If you have any questions or
-            concerns,
-            please feel free to
-              <a data-toggle="tab" className="hash-link" href="#contact">contact us</a>.</p>
+          <p>
+            We are not responsible for the actions of any service providers or other third parties, nor are we
+            responsible for any additional information you provide directly to any third parties, and we encourage you to become
+            familiar with their privacy practices before disclosing information directly to any such parties. Nothing herein
+            restricts the sharing of aggregated or anonymized information, which may be shared with third parties without your consent.
+          </p>
+          <p>
+            Town Hall Project is volunteer driven and your experience is important to us. If you have any questions or
+            concerns, please feel free to <a data-toggle="tab" className="hash-link" href="#contact"> contact us</a>.
+          </p>
         </div>
       </section>
       <div className="banner" id="cover">


### PR DESCRIPTION
Description
• Removes sentence with broken links in privacy policy
• Updates spaces for contact info
• cleans up privacy policy to make html more easily readable 

Fixes #706 

Before
![image](https://user-images.githubusercontent.com/3753457/89854095-d8855880-db47-11ea-956b-f8d3d8adec5c.png)

![image](https://user-images.githubusercontent.com/3753457/89854009-9d832500-db47-11ea-8662-6e1ee4fa7c5e.png)

Small updates
![image](https://user-images.githubusercontent.com/3753457/89854114-e63ade00-db47-11ea-8263-e5a74599a0ae.png)

![image](https://user-images.githubusercontent.com/3753457/89854026-aaa01400-db47-11ea-8b9b-ab2792f60bb6.png)
